### PR TITLE
feat: Optimize NA value recognition

### DIFF
--- a/src/render/portable/plot.rs
+++ b/src/render/portable/plot.rs
@@ -1,5 +1,5 @@
 use crate::render::portable::utils::minify_js;
-use crate::utils::column_type::{classify_table, ColumnType};
+use crate::utils::column_type::{classify_table, ColumnType, IsNa};
 use anyhow::{Context as AnyhowContext, Result};
 use csv::Reader;
 use itertools::Itertools;
@@ -167,7 +167,7 @@ fn generate_nominal_plot(
     for record in reader.records().skip(header_rows - 1) {
         let result = record?;
         let value = result.get(column_index).unwrap();
-        if !value.is_empty() {
+        if !value.is_na() {
             let entry = count_values.entry(value.to_owned()).or_insert_with(|| 0);
             *entry += 1;
         } else {

--- a/src/utils/column_type.rs
+++ b/src/utils/column_type.rs
@@ -15,7 +15,7 @@ pub(crate) enum ColumnType {
 
 impl ColumnType {
     fn update(&mut self, value: &str) -> Result<()> {
-        if !value.is_empty() {
+        if !value.is_na() {
             *self = match (
                 f64::from_str(value).is_ok(),
                 i64::from_str(value).is_ok(),
@@ -64,6 +64,16 @@ pub(crate) fn classify_table<P: AsRef<Path>>(
     }
 
     Ok(classification)
+}
+
+pub(crate) trait IsNa {
+    fn is_na(&self) -> bool;
+}
+
+impl IsNa for &str {
+    fn is_na(&self) -> bool {
+        self.is_empty() || self == &"NA"
+    }
 }
 
 #[cfg(test)]

--- a/templates/table.js.tera
+++ b/templates/table.js.tera
@@ -191,8 +191,10 @@ $(document).ready(function() {
                let plot_data = [];
                let values = []
                for (row of table_rows) {
-                   plot_data.push({"value": parseFloat(row[title])});
-                   values.push(parseFloat(row[title]));
+                   if (row[title] != "" && row[title] != "NA") {
+                       plot_data.push({"value": parseFloat(row[title])});
+                       values.push(parseFloat(row[title]));
+                   }
                }
                let min = Math.min(...values);
                let max = Math.max(...values);


### PR DESCRIPTION
This PR optimizes datavzrds recognition of `NA` values. `&str` now implement an `isNa` trait for easier further future modification if needed. This also fixes a small bug with the filter brush plot that occurred with `NA` values.