### PR TITLE
fix: Add missing clamp parameter to heatmap plot

### DIFF
--- a/src/render/portable/mod.rs
+++ b/src/render/portable/mod.rs
@@ -454,6 +454,14 @@ fn render_table_heatmap<P: AsRef<Path>>(
         .filter(|(_, s)| !s.is_empty())
         .collect();
 
+    let clamps: HashMap<_, _> = render_columns
+        .iter()
+        .filter(|(_, r)| r.plot.is_some())
+        .map(|(t, rc)| (t, rc.plot.as_ref().unwrap()))
+        .filter(|(_, p)| p.heatmap.is_some())
+        .map(|(t, p)| (t, &p.heatmap.as_ref().unwrap().clamp))
+        .collect();
+
     let remove_legend: HashMap<_, _> = titles
         .iter()
         .tuple_windows()
@@ -498,6 +506,7 @@ fn render_table_heatmap<P: AsRef<Path>>(
     context.insert("ranges", &ranges);
     context.insert("schemes", &schemes);
     context.insert("scales", &scales);
+    context.insert("clamps", &clamps);
     context.insert("columns", &columns);
     context.insert("types", &column_types);
     context.insert("marks", &marks);

--- a/templates/table_heatmap.js.tera
+++ b/templates/table_heatmap.js.tera
@@ -64,6 +64,7 @@ const heatmap_plot = {
                             {% if scales[column] %}"type": "{{ scales[column] }}",{% endif %}
                             {% if schemes[column] %}"scheme": "{{ schemes[column] }}",{% elif not ranges[column] and types[column] == "quantitative" %}"scheme": "blues",{% endif %}
                             {% if ranges[column] %}"range": {{ ranges[column] | json_encode }},{% endif %}
+                            {% if clamps[column] and scales[column] != "ordinal" %}"clamp": {{ clamps[column] | json_encode }},{% endif %}
                         },{% endif %}
                         {% if marks[column] != "text" %}"legend": {% if remove_legend[column] or not plot_legend[column] %}null{% else %}{
                             "orient": "bottom",


### PR DESCRIPTION
This PR quickly adds the `clamp` option to the heatmap plot.