### PR TITLE
docs: Update repository link in badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/koesterlab/datavzrd/rust.yml?branch=main&label=tests)](https://github.com/koesterlab/datavzrd/actions)
+[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/datavzrd/datavzrd/rust.yml?branch=main&label=tests)](https://github.com/datavzrd/datavzrd/actions)
 [![Conda Recipe](https://img.shields.io/badge/recipe-datavzrd-green.svg)](https://anaconda.org/conda-forge/datavzrd)
 [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/datavzrd.svg)](https://anaconda.org/conda-forge/datavzrd)
 [![Conda Version](https://img.shields.io/conda/vn/conda-forge/datavzrd.svg)](https://anaconda.org/conda-forge/datavzrd)


### PR DESCRIPTION
Since we moved datavzrd into its own org the links should be updated as well.