### PR TITLE
fix: Fix precision keyword for bar and tick plots

### DIFF
--- a/src/spec.rs
+++ b/src/spec.rs
@@ -102,7 +102,7 @@ impl ItemsSpec {
                         .delimiter(dataset.separator as u8)
                         .from_path(&dataset.path)?;
                     let titles = reader.headers()?.iter().map(|s| s.to_owned()).collect_vec();
-                    let column_types = classify_table(&dataset.path, dataset.separator)?; // TODO: Add dataset.header_rows as third parameter when #298 is merged
+                    let column_types = classify_table(&dataset.path, dataset.separator, dataset.header_rows)?;
                     for (column, render_columns) in &render_table.columns {
                         if !titles.contains(column) && !render_columns.optional {
                             warn!("Found render-table definition for column {} that is not part of the given dataset.", &column);

--- a/templates/table.js.tera
+++ b/templates/table.js.tera
@@ -527,13 +527,13 @@ function render(additional_headers, displayed_columns, table_rows, columns, conf
 
 for (o of config.ticks) {
     if (displayed_columns.includes(o.title)) {
-        renderTickPlot(additional_headers.length, displayed_columns, o.title, o.slug_title, o.specs, o.is_float, o.precision, config.detail_mode, config.header_label_length);
+        renderTickPlot(additional_headers.length, displayed_columns, o.title, o.slug_title, o.specs, config[o.title].is_float, config[o.title].precision, config.detail_mode, config.header_label_length);
     }
 }
 
 for (o of config.bars) {
     if (displayed_columns.includes(o.title)) {
-        renderBarPlot(additional_headers.length, displayed_columns, o.title, o.slug_title, o.specs, o.is_float, o.precision, config.detail_mode, config.header_label_length);
+        renderBarPlot(additional_headers.length, displayed_columns, o.title, o.slug_title, o.specs, config[o.title].is_float, config[o.title].precision, config.detail_mode, config.header_label_length);
     }
 }
 


### PR DESCRIPTION
This PR fixes the precision keyword for bar and tick plots and also fixes a small todo item that got introduced with merging #298 and #299.