### PR TITLE
docs: Fix color-scheme of view movies

### DIFF
--- a/.examples/example-config.yaml
+++ b/.examples/example-config.yaml
@@ -82,7 +82,7 @@ views:
           plot:
             heatmap:
               scale: ordinal
-              color-scheme: accent
+              color-scheme: tableau20
         Runtime:
           custom-path: ".examples/specs/time-formatter.js"
   movies-plot:


### PR DESCRIPTION
Just a quick PR that changes the color-scheme of column `Rated` from `accent` to `tableau20` due to `accent` only providing 8 different color values while the domain of  `Rated` has more than 8 different values.