### PR TITLE
fix: Remove validation error when values exceed given domain and clamp is set to true

### DIFF
--- a/src/spec.rs
+++ b/src/spec.rs
@@ -189,9 +189,8 @@ impl ItemsSpec {
                                     let record = record?;
                                     let value = record.get(colum_pos).unwrap();
                                     if let Ok(value) = value.parse::<f32>() {
-                                        if value < domain[0]
-                                            || value > domain[domain.len() - 1]
-                                            || clamp
+                                        if (value < domain[0] || value > domain[domain.len() - 1])
+                                            && !clamp
                                         {
                                             bail!(ValueOutsideDomain {
                                                 view: name.to_string(),

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -173,6 +173,11 @@ impl ItemsSpec {
                             } else {
                                 plot_spec.heatmap.as_ref().map(|heatmap| heatmap.scale_type)
                             };
+                            let clamp = if let Some(heatmap) = &plot_spec.heatmap {
+                                heatmap.clamp
+                            } else {
+                                false
+                            };
                             if let Some(domain) = domain {
                                 let mut reader = csv::ReaderBuilder::new()
                                     .delimiter(dataset.separator as u8)
@@ -184,7 +189,10 @@ impl ItemsSpec {
                                     let record = record?;
                                     let value = record.get(colum_pos).unwrap();
                                     if let Ok(value) = value.parse::<f32>() {
-                                        if value < domain[0] || value > domain[domain.len() - 1] {
+                                        if value < domain[0]
+                                            || value > domain[domain.len() - 1]
+                                            || clamp
+                                        {
                                             bail!(ValueOutsideDomain {
                                                 view: name.to_string(),
                                                 column: column.to_string(),


### PR DESCRIPTION
This PR fixes an error with clamped scales during the config validation.