### PR TITLE
fix: Fix headers for views without detail mode and no header labels

### DIFF
--- a/templates/table.js.tera
+++ b/templates/table.js.tera
@@ -102,7 +102,7 @@ $(document).ready(function() {
         {% if detail_mode %}detailView: true, detailFormatter: "detailFormatter"{% endif %}
     })
 
-    let additional_headers = "{% if additional_headers %}{% for ah in additional_headers %}<tr><td {% if not detail_mode %}style='border: none !important;'{% endif%}>{% if header_labels[loop.index] %}<b>{{ header_labels[loop.index] }}</b>{% endif %}</td>{% for title in titles %}{% if display_modes[title] == "normal" %}<td>{{ ah[title] }}</td>{% endif %}{% endfor %}</tr>{% endfor %}{% endif %}";
+    let additional_headers = "{% if additional_headers %}{% for ah in additional_headers %}<tr>{% if detail_mode or header_labels[loop.index] %}<td {% if not detail_mode %}style='border: none !important;'{% endif%}>{% endif%}{% if header_labels[loop.index] %}<b>{{ header_labels[loop.index] }}</b>{% endif %}</td>{% for title in titles %}{% if display_modes[title] == "normal" %}<td>{{ ah[title] }}</td>{% endif %}{% endfor %}</tr>{% endfor %}{% endif %}";
     let cp = [{% for title, custom_plot in custom_plots %}"{{ title }}"{% if not loop.last %},{% endif %}{% endfor %}];
 
     var header_height = (80+6*Math.max(...(config.displayed_columns.map(el => el.length)))*Math.SQRT2)/2 {% if is_single_page %} + 45{% endif %};


### PR DESCRIPTION
This PR fixes the out of position headers when a dataset had additional headers and no label was defined and the view didn't have any columns with `display-mode: detail`.