### PR TITLE
feat: Add ellipsis option for header definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,8 @@ views:
 |---------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | label         | Allows to add an additional label to the corresponding header                                                                                                 |
 | [plot](#plot) | Renders a vega-lite plot defined with [plot](#plot) to the corresponding table cell (currently only the [heatmap](#heatmap) type is supported in header rows) |
-| display-mode  | Allows to hide the header row by setting this to `hidden`. |
+| display-mode  | Allows to hide the header row by setting this to `hidden`.  |
+| ellipsis      | Shortens values to the first *n* given characters with the rest hidden behind a popover.                                                                      |
 
 ### render-plot
 

--- a/src/render/portable/mod.rs
+++ b/src/render/portable/mod.rs
@@ -727,6 +727,16 @@ fn render_table_javascript<P: AsRef<Path>>(
         HashMap::new()
     };
 
+    let header_ellipsis: HashMap<u32, u32> = if let Some(headers) = header_specs {
+        headers
+            .iter()
+            .filter(|(_, h)| h.ellipsis.is_some())
+            .map(|(k, v)| (*k, v.ellipsis.unwrap()))
+            .collect()
+    } else {
+        HashMap::new()
+    };
+
     let header_labels: HashMap<u32, String> = if let Some(headers) = header_specs {
         headers
             .iter()
@@ -807,6 +817,7 @@ fn render_table_javascript<P: AsRef<Path>>(
     context.insert("precisions", &precisions);
     context.insert("additional_headers", &header_rows);
     context.insert("header_heatmaps", &header_heatmaps);
+    context.insert("header_ellipsis", &header_ellipsis);
     context.insert("header_labels", &header_labels);
     context.insert("formatter", &Some(formatters));
     context.insert("custom_plots", &custom_plots);

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -364,6 +364,8 @@ pub(crate) struct HeaderSpecs {
     pub(crate) plot: Option<PlotSpec>,
     #[serde(default)]
     pub(crate) display_mode: HeaderDisplayMode,
+    #[serde(default)]
+    pub(crate) ellipsis: Option<u32>,
 }
 
 lazy_static! {
@@ -1040,6 +1042,7 @@ mod tests {
                             bar_plot: None,
                         }),
                         display_mode: HeaderDisplayMode::Normal,
+                        ellipsis: None,
                     },
                 )])),
             }),

--- a/static/datavzrd.js
+++ b/static/datavzrd.js
@@ -138,6 +138,18 @@ function shortenColumn(ah, columns, title, ellipsis, detail_mode, header_label_l
     );
 }
 
+function shortenHeaderRow(row, ellipsis, skip_label) {
+    $(`table > thead > tr:nth-child(${row + 1}) > td`).each(
+        function() {
+            value = this.innerHTML;
+            if (value.length > ellipsis && !skip_label) {
+                this.innerHTML = `${value.substring(0, ellipsis)}<a tabindex="0" role="button" href="#" data-toggle="popover" data-trigger="focus" data-html='true' data-content='<div style="overflow: auto; max-height: 30vh; max-width: 25vw;">${value}</div>'>...</a>`;
+            }
+            skip_label = false;
+        }
+    );
+}
+
 
 function linkUrlColumn(ah, dp_columns, columns, title, link_url, detail_mode, header_label_length) {
     let index = dp_columns.indexOf(title) + 1;

--- a/templates/table.js.tera
+++ b/templates/table.js.tera
@@ -425,6 +425,23 @@ function colorizeHeaderRow{{ loop.index0 }}() {
 }
 {% endfor %}
 
+{% for row, l in header_ellipsis %}
+    function shortenHeaderRow{{ loop.index0 }}() {
+        var row = {{ row }};
+        var ellipsis = {{ l }};
+        var skip_label = {% if not header_labels | length == 0 %}true{% else %}false{% endif %};
+        $(`table > thead > tr:nth-child(${row + 1}) > td`).each(
+            function() {
+                value = this.innerHTML;
+                if (value.length > ellipsis && !skip_label) {
+                    this.innerHTML = `${value.substring(0, ellipsis)}<a tabindex="0" role="button" href="#" data-toggle="popover" data-trigger="focus" data-html='true' data-content='<div style="overflow: auto; max-height: 30vh; max-width: 25vw;">${value}</div>'>...</a>`;
+                }
+                skip_label = false;
+            }
+        );
+    }
+{% endfor %}
+
 {% for title, tuple in heatmaps %}
 function colorizeDetailCard(value, div, scale) {
     if (value !== "") {
@@ -558,6 +575,9 @@ for (o of config.ellipsis) {
 
 {% for row, heatmap in header_heatmaps %}
     colorizeHeaderRow{{ loop.index0 }}();
+{% endfor %}
+{% for row, l in header_ellipsis %}
+    shortenHeaderRow{{ loop.index0 }}();
 {% endfor %}
 $('[data-toggle="popover"]').popover()
 {% if not detail_mode and not header_labels | length == 0 %}

--- a/templates/table.js.tera
+++ b/templates/table.js.tera
@@ -562,7 +562,7 @@ for (o of config.ellipsis) {
 {% endfor %}
 
 for (o of config.header_ellipsis) {
-    shortenHeaderRow(o.index, o.ellipsis, {% if not header_labels | length == 0 %}true{% else %}false{% endif %});
+    shortenHeaderRow(o.index, o.ellipsis, {{ header_labels | length > 0 }});
 }
 
 $('[data-toggle="popover"]').popover()

--- a/templates/table.js.tera
+++ b/templates/table.js.tera
@@ -14,6 +14,7 @@ const config = {
     {% endfor %}
     "detail_mode": {{ detail_mode }},
     "header_label_length": {{ header_labels | length }},
+    "header_ellipsis": [{% for row, l in header_ellipsis %}{"index": {{ row }}, "ellipsis": {{ l }}}{% endfor %}],
     "ticks": [
         {% for title, tick_plot in tick_plots %}
         {
@@ -425,23 +426,6 @@ function colorizeHeaderRow{{ loop.index0 }}() {
 }
 {% endfor %}
 
-{% for row, l in header_ellipsis %}
-    function shortenHeaderRow{{ loop.index0 }}() {
-        var row = {{ row }};
-        var ellipsis = {{ l }};
-        var skip_label = {% if not header_labels | length == 0 %}true{% else %}false{% endif %};
-        $(`table > thead > tr:nth-child(${row + 1}) > td`).each(
-            function() {
-                value = this.innerHTML;
-                if (value.length > ellipsis && !skip_label) {
-                    this.innerHTML = `${value.substring(0, ellipsis)}<a tabindex="0" role="button" href="#" data-toggle="popover" data-trigger="focus" data-html='true' data-content='<div style="overflow: auto; max-height: 30vh; max-width: 25vw;">${value}</div>'>...</a>`;
-                }
-                skip_label = false;
-            }
-        );
-    }
-{% endfor %}
-
 {% for title, tuple in heatmaps %}
 function colorizeDetailCard(value, div, scale) {
     if (value !== "") {
@@ -576,9 +560,13 @@ for (o of config.ellipsis) {
 {% for row, heatmap in header_heatmaps %}
     colorizeHeaderRow{{ loop.index0 }}();
 {% endfor %}
-{% for row, l in header_ellipsis %}
-    shortenHeaderRow{{ loop.index0 }}();
-{% endfor %}
+
+for (o of config.header_ellipsis) {
+    shortenHeaderRow(o.index, o.ellipsis, {% if not header_labels | length == 0 %}true{% else %}false{% endif %});
+}
+
+
+
 $('[data-toggle="popover"]').popover()
 {% if not detail_mode and not header_labels | length == 0 %}
 $(`table > tbody > tr td:first-child`).each(function() {this.style.setProperty("visibility", "hidden"); this.style.setProperty("border", "none");});

--- a/templates/table.js.tera
+++ b/templates/table.js.tera
@@ -565,8 +565,6 @@ for (o of config.header_ellipsis) {
     shortenHeaderRow(o.index, o.ellipsis, {% if not header_labels | length == 0 %}true{% else %}false{% endif %});
 }
 
-
-
 $('[data-toggle="popover"]').popover()
 {% if not detail_mode and not header_labels | length == 0 %}
 $(`table > tbody > tr td:first-child`).each(function() {this.style.setProperty("visibility", "hidden"); this.style.setProperty("border", "none");});


### PR DESCRIPTION
This PR adds the already for columns existing keyword `ellipsis` to header definitions as well allowing to shorten values to the first n characters with the full content displayed as a popover on hover.