### PR TITLE
perf: Compress data for plot views with lz-string

### DIFF
--- a/src/render/portable/mod.rs
+++ b/src/render/portable/mod.rs
@@ -1254,7 +1254,9 @@ fn render_plot_page<P: AsRef<Path>>(
 
     let local: DateTime<Local> = Local::now();
 
-    context.insert("data", &json!(records).to_string());
+    let compressed_data = compress_to_utf16(&json!(records).to_string());
+
+    context.insert("data", &json!(compressed_data).to_string());
     context.insert("description", &item_spec.description);
     context.insert("has_excel_sheet", &has_excel_sheet);
     context.insert(
@@ -1423,7 +1425,9 @@ fn render_plot_page_with_multiple_datasets<P: AsRef<Path>>(
 
     let local: DateTime<Local> = Local::now();
 
-    context.insert("datasets", &json!(data).to_string());
+    let compressed_data = compress_to_utf16(&json!(data).to_string());
+
+    context.insert("datasets", &json!(compressed_data).to_string());
     context.insert("description", &item_spec.description);
     context.insert(
         "tables",

--- a/templates/plot.html.tera
+++ b/templates/plot.html.tera
@@ -82,12 +82,12 @@
                         {% if data %}
                         const data = {{ data | safe }};
                         specs.data = {};
-                        specs.data.values = data;
+                        specs.data.values = JSON.parse(LZString.decompressFromUTF16(data));
                         {% endif %}
                         {% if datasets %}
                         const data = {{ datasets | safe }};
                         specs.datasets = {};
-                        specs.datasets = data;
+                        specs.datasets = JSON.parse(LZString.decompressFromUTF16(data));
                         {% endif %}
                         if (specs.width == "container") { $("#vis").css("width", "100%"); }
                         vegaEmbed('#vis', specs);


### PR DESCRIPTION
This PR fixes #292 by also storing the plot data in a compressed version.