### PR TITLE
perf: Remove html search pages for views that don't use them

### DIFF
--- a/src/render/portable/mod.rs
+++ b/src/render/portable/mod.rs
@@ -200,6 +200,15 @@ impl Renderer for ItemRenderer {
                             &headers,
                             dataset.header_rows,
                         )?;
+                    } else {
+                        render_search_dialogs(
+                            &out_path,
+                            &headers,
+                            &dataset.path,
+                            dataset.separator,
+                            table.page_size,
+                            dataset.header_rows,
+                        )?;
                     }
                     render_table_javascript(
                         &out_path,
@@ -216,14 +225,6 @@ impl Renderer for ItemRenderer {
                         &out_path,
                         &dataset.path,
                         dataset.separator,
-                        dataset.header_rows,
-                    )?;
-                    render_search_dialogs(
-                        &out_path,
-                        &headers,
-                        &dataset.path,
-                        dataset.separator,
-                        table.page_size,
                         dataset.header_rows,
                     )?;
                 }


### PR DESCRIPTION
This PR fixes #316. This should reduce the storage space significantly.