### PR TITLE
fix: Turn off webview controls by default

### DIFF
--- a/.examples/example-config.yaml
+++ b/.examples/example-config.yaml
@@ -18,6 +18,7 @@ datasets:
         column: Title
         table-row: oscars/movie
 default-view: oscars
+webview-controls: true
 views:
   oscars:
     dataset: oscars

--- a/README.md
+++ b/README.md
@@ -129,6 +129,10 @@ views:
 
 `aux-libraries` allows to add one or more js libraries via cdn links for usage in [render-html](#render-html). The keyword expects a list of urls that link to the js libraries.
 
+### webview-controls
+
+`webview-controls` allows to turn on sharing individual rows via a link with the data encoded into a url pointing to a webview that hosts a static version of datavzrd. Note that when using the link the row data can temporarily occur (in base64-encoded form) in the server logs of the given webview host. Defaults to `false`.
+
 ### datasets
 
 `datasets` defines the different datasets of the report. This is also the place to define links between your individual datasets.

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ views:
 
 ### webview-controls
 
-`webview-controls` allows to turn on sharing individual rows via a link with the data encoded into a url pointing to a webview that hosts a static version of datavzrd. Note that when using the link the row data can temporarily occur (in base64-encoded form) in the server logs of the given webview host. Defaults to `false`.
+`webview-controls` allows to turn on sharing individual rows via a link with the data encoded into a url pointing to a webview that hosts a static version of datavzrd at https://datavzrd.github.io. Note that when using the link the row data can temporarily occur (in base64-encoded form) in the server logs of the given webview host. Defaults to `false`.
 
 ### datasets
 

--- a/src/render/portable/mod.rs
+++ b/src/render/portable/mod.rs
@@ -222,6 +222,7 @@ impl Renderer for ItemRenderer {
                         is_single_page,
                         table.single_page_page_size,
                         &webview_host,
+                        self.specs.webview_controls,
                     )?;
                     render_plots(
                         &out_path,
@@ -583,6 +584,7 @@ fn render_table_javascript<P: AsRef<Path>>(
     is_single_page: bool,
     page_size: usize,
     webview_host: &String,
+    webview_controls: bool,
 ) -> Result<()> {
     let mut templates = Tera::default();
     templates.add_raw_template(
@@ -850,6 +852,7 @@ fn render_table_javascript<P: AsRef<Path>>(
     context.insert("is_single_page", &is_single_page);
     context.insert("page_size", &page_size);
     context.insert("webview_host", &webview_host);
+    context.insert("webview_controls", &webview_controls);
 
     let file_path = Path::new(output_path.as_ref()).join(Path::new("table").with_extension("js"));
 

--- a/src/render/portable/utils.rs
+++ b/src/render/portable/utils.rs
@@ -147,7 +147,7 @@ mod tests {
             max_in_memory_rows: 1000,
             views: Default::default(),
             aux_libraries: None,
-            webview_controls: false
+            webview_controls: false,
         };
         render_index_file(Path::new("/tmp"), &spec).unwrap();
         let rendered_file_content = fs::read_to_string("/tmp/index.html")

--- a/src/render/portable/utils.rs
+++ b/src/render/portable/utils.rs
@@ -147,6 +147,7 @@ mod tests {
             max_in_memory_rows: 1000,
             views: Default::default(),
             aux_libraries: None,
+            webview_controls: false
         };
         render_index_file(Path::new("/tmp"), &spec).unwrap();
         let rendered_file_content = fs::read_to_string("/tmp/index.html")

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -1339,7 +1339,7 @@ mod tests {
                     dataset: table-a
             "#;
         let err = serde_yaml::from_str::<ItemsSpec>(raw_config).unwrap_err();
-        assert_eq!(err.to_string(), "unknown field `non-existing-keyword`, expected one of `name`, `datasets`, `default-view`, `max-in-memory-rows`, `views`, `aux-libraries` at line 5 column 13");
+        assert_eq!(err.to_string(), "unknown field `non-existing-keyword`, expected one of `name`, `datasets`, `default-view`, `max-in-memory-rows`, `views`, `aux-libraries`, `webview-controls` at line 5 column 13");
     }
 
     #[test]

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -36,6 +36,8 @@ pub(crate) struct ItemsSpec {
     pub(crate) max_in_memory_rows: usize,
     pub(crate) views: HashMap<String, ItemSpecs>,
     pub(crate) aux_libraries: Option<Vec<String>>,
+    #[serde(default)]
+    pub(crate) webview_controls: bool,
 }
 
 impl ItemsSpec {

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -878,7 +878,7 @@ mod tests {
             views: HashMap::from([("table-a".to_string(), expected_table_spec)]),
             report_name: "my_report".to_string(),
             aux_libraries: None,
-            webview_controls: false
+            webview_controls: false,
         };
 
         let raw_config = r#"
@@ -947,7 +947,7 @@ mod tests {
             views: HashMap::from([("plot-a".to_string(), expected_item_spec)]),
             report_name: "".to_string(),
             aux_libraries: None,
-            webview_controls: false
+            webview_controls: false,
         };
 
         let raw_config = r#"
@@ -1006,7 +1006,7 @@ mod tests {
             views: HashMap::from([("plot-a".to_string(), expected_item_spec)]),
             report_name: "".to_string(),
             aux_libraries: Some(Vec::from(["https://cdnjs.org/d3.js".to_string()])),
-            webview_controls: false
+            webview_controls: false,
         };
 
         let raw_config = r#"
@@ -1081,7 +1081,7 @@ mod tests {
             views: HashMap::from([("plot-a".to_string(), expected_item_spec)]),
             report_name: "".to_string(),
             aux_libraries: None,
-            webview_controls: false
+            webview_controls: false,
         };
 
         let raw_config = r#"

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -878,6 +878,7 @@ mod tests {
             views: HashMap::from([("table-a".to_string(), expected_table_spec)]),
             report_name: "my_report".to_string(),
             aux_libraries: None,
+            webview_controls: false
         };
 
         let raw_config = r#"
@@ -946,6 +947,7 @@ mod tests {
             views: HashMap::from([("plot-a".to_string(), expected_item_spec)]),
             report_name: "".to_string(),
             aux_libraries: None,
+            webview_controls: false
         };
 
         let raw_config = r#"
@@ -1004,6 +1006,7 @@ mod tests {
             views: HashMap::from([("plot-a".to_string(), expected_item_spec)]),
             report_name: "".to_string(),
             aux_libraries: Some(Vec::from(["https://cdnjs.org/d3.js".to_string()])),
+            webview_controls: false
         };
 
         let raw_config = r#"
@@ -1078,6 +1081,7 @@ mod tests {
             views: HashMap::from([("plot-a".to_string(), expected_item_spec)]),
             report_name: "".to_string(),
             aux_libraries: None,
+            webview_controls: false
         };
 
         let raw_config = r#"

--- a/templates/table.js.tera
+++ b/templates/table.js.tera
@@ -98,7 +98,7 @@ $(document).ready(function() {
         bs_table_cols.push({field: 'linkouts', title: '', formatter: function(value){ return value }});
     }
 
-    bs_table_cols.push({field: 'share', title: '', formatter: function(value){ return value }});
+    {% if webview_controls %}bs_table_cols.push({field: 'share', title: '', formatter: function(value){ return value }});{% endif %}
 
     $('#table').bootstrapTable({
         columns: bs_table_cols,
@@ -125,7 +125,7 @@ $(document).ready(function() {
         if (linkouts != null) {
             row["linkouts"] = decompressed_linkouts[j];
         }
-        row["share"] = `<span data-toggle="tooltip" data-placement="left" title="Share link via QR code. Note that when using the link the row data can temporarily occur (in base64-encoded form) in the server logs of {{webview_host}}.">
+        {% if webview_controls %}row["share"] = `<span data-toggle="tooltip" data-placement="left" title="Share link via QR code. Note that when using the link the row data can temporarily occur (in base64-encoded form) in the server logs of {{webview_host}}.">
         <button class="btn btn-outline-secondary share-btn" onclick="shareRow(${j}, '{{webview_host}}')">
         <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-qr-code" viewBox="0 0 16 16">
             <path d="M2 2h2v2H2V2Z"/>
@@ -142,7 +142,7 @@ $(document).ready(function() {
                     <path d="M10 .5a.5.5 0 0 0-.5-.5h-3a.5.5 0 0 0-.5.5.5.5 0 0 1-.5.5.5.5 0 0 0-.5.5V2a.5.5 0 0 0 .5.5h5A.5.5 0 0 0 11 2v-.5a.5.5 0 0 0-.5-.5.5.5 0 0 1-.5-.5Z"/>
                 </svg>
             </button>
-        </span>`;
+        </span>`;{% endif %}
         j++;
         table_rows.push(row);
     }


### PR DESCRIPTION
This PR closes #328 by adding a `webview-controls` option to the config that is turned off by default.