### PR TITLE
fix: Fix non-working filter if brush is dragged outside of plot

### DIFF
--- a/templates/table.js.tera
+++ b/templates/table.js.tera
@@ -325,6 +325,11 @@ $(document).ready(function() {
                            'filterAlgorithm': customFilter
                        })
                    });
+                    view.addEventListener('mouseleave', function(name, value) {
+                        $('#table').bootstrapTable('filterBy', {"":""}, {
+                            'filterAlgorithm': customFilter
+                        })
+                    });
                })
            } else {
            if(!reset){

--- a/templates/table.js.tera
+++ b/templates/table.js.tera
@@ -325,7 +325,8 @@ $(document).ready(function() {
                            'filterAlgorithm': customFilter
                        })
                    });
-                    view.addEventListener('mouseleave', function(name, value) {
+                   // Add another event listener so the filter is still triggered when the brush is dragged outside the plot.
+                   view.addEventListener('mouseleave', function(name, value) {
                         $('#table').bootstrapTable('filterBy', {"":""}, {
                             'filterAlgorithm': customFilter
                         })


### PR DESCRIPTION
This PR fixes a small problem where filter brushes weren't applied if they're dragged outside of the plot. This PR fixes this by adding another event that triggers the filer.