### PR TITLE
ci: Specify newest version of apply-clippy-lints

### DIFF
--- a/.github/workflows/apply-clippy-lints.yaml
+++ b/.github/workflows/apply-clippy-lints.yaml
@@ -12,4 +12,4 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Auto apply clippy lints
-        uses: fxwiegand/apply-clippy-lints@v1
+        uses: fxwiegand/apply-clippy-lints@v1.0.4


### PR DESCRIPTION
This PR pins apply-clippy-lints to the most recent version.