### PR TITLE
build(deps): Pin minify-js to 0.5.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ lazy_static = "1.4.0"
 regex = "1.7.1"
 log = "0.4.17"
 simplelog = "0.12.0"
-minify-js = "0.5.6"
+minify-js = "=0.5.2"
 simple_excel_writer = "0.2"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ lazy_static = "1.4.0"
 regex = "1.7.1"
 log = "0.4.17"
 simplelog = "0.12.0"
-minify-js = "=0.5.2"
+minify-js = "=0.5.2" # newer versions generate display issues (see PR #375)
 simple_excel_writer = "0.2"
 
 [dev-dependencies]


### PR DESCRIPTION
The newest  version of minify-js seems to create some problems: 
<img width="1267" alt="Bildschirmfoto 2023-02-21 um 13 26 58" src="https://user-images.githubusercontent.com/39430842/220344812-d7f33976-e086-4037-82d2-d68f3a26a904.png">
 Version 0.5.2 seems to work fine.