### PR TITLE
fix: Fix domain detection with NA values

### DIFF
--- a/src/render/portable/mod.rs
+++ b/src/render/portable/mod.rs
@@ -12,6 +12,7 @@ use crate::spec::{
     LinkSpec, RenderColumnSpec, ScaleType, TickPlot,
 };
 use crate::utils::column_index::ColumnIndex;
+use crate::utils::column_type::IsNa;
 use crate::utils::column_type::{classify_table, ColumnType};
 use crate::utils::row_address::RowAddressFactory;
 use anyhow::Result;
@@ -1146,11 +1147,13 @@ pub(crate) fn get_column_domain(
             })?;
             Ok(json!(reader
                 .records()
+                .skip(header_rows - 1)
                 .map(|r| r.unwrap())
                 .flat_map(|r| r
                     .iter()
                     .enumerate()
                     .filter(|(index, _)| column_indexes.contains(index))
+                    .filter(|(_, value)| !value.is_na())
                     .map(|(_, value)| value.to_string())
                     .collect_vec())
                 .unique()
@@ -1160,8 +1163,10 @@ pub(crate) fn get_column_domain(
         } else {
             Ok(json!(reader
                 .records()
+                .skip(header_rows - 1)
                 .map(|r| r.unwrap())
                 .map(|r| r.get(column_index).unwrap().to_owned())
+                .filter(|value| !value.as_str().is_na())
                 .unique()
                 .sorted()
                 .collect_vec())


### PR DESCRIPTION
This PR fixes the domain detection when NA values occur so that they'll be excluded in the domain in the future. That way NA values won't take up one spot in an ordinal color scheme for example.