### PR TITLE
fix: Pre-calculate numeric heatmap domain

### DIFF
--- a/src/spec.rs
+++ b/src/spec.rs
@@ -592,7 +592,7 @@ impl TickPlot {
 impl Heatmap {
     fn preprocess(&mut self, dataset: &DatasetSpecs, title: &str) -> Result<()> {
         self.aux_domain_columns.preprocess(dataset)?;
-        if !self.scale_type.is_quantitative() && self.domain.is_none() {
+        if self.domain.is_none() {
             let d = get_column_domain(
                 title,
                 &dataset.path,
@@ -600,7 +600,12 @@ impl Heatmap {
                 dataset.header_rows,
                 self,
             )?;
-            let domain: Vec<String> = serde_json::from_str(&d)?;
+            let domain: Vec<String> = if self.scale_type.is_quantitative() {
+                let floating_domain: Vec<f64> = serde_json::from_str(&d)?;
+                floating_domain.iter().map(|x| x.to_string()).collect()
+            } else {
+                serde_json::from_str(&d)?
+            };
             self.domain = Some(domain);
         }
         Ok(())

--- a/static/datavzrd.js
+++ b/static/datavzrd.js
@@ -136,40 +136,20 @@ function colorizeColumn(ah, columns, heatmap, detail_mode, header_label_length) 
     let scale = null;
 
     if (heatmap.heatmap.scale == "ordinal") {
-        if (heatmap.heatmap.domain != null) {
-            if (heatmap.heatmap.color_scheme != "") {
-                scale = vega.scale(heatmap.heatmap.scale)().domain(heatmap.heatmap.domain).range(vega.scheme(heatmap.heatmap.color_scheme));
-            } else if (!heatmap.heatmap.range.length == 0) {
-                scale = vega.scale(heatmap.heatmap.scale)().domain(heatmap.heatmap.domain).range(heatmap.heatmap.range);
-            } else {
-                scale = vega.scale(heatmap.heatmap.scale)().domain(heatmap.heatmap.domain);
-            }
+        if (heatmap.heatmap.color_scheme != "") {
+            scale = vega.scale(heatmap.heatmap.scale)().domain(heatmap.heatmap.domain).range(vega.scheme(heatmap.heatmap.color_scheme));
+        } else if (!heatmap.heatmap.range.length == 0) {
+            scale = vega.scale(heatmap.heatmap.scale)().domain(heatmap.heatmap.domain).range(heatmap.heatmap.range);
         } else {
-            if (heatmap.heatmap.color_scheme != "") {
-                scale = vega.scale(heatmap.heatmap.scale)().range(vega.scheme(heatmap.heatmap.color_scheme));
-            } else if (!heatmap.heatmap.range.length == 0) {
-                scale = vega.scale(heatmap.heatmap.scale)().range(heatmap.heatmap.range);
-            } else {
-                scale = vega.scale(heatmap.heatmap.scale)();
-            }
+            scale = vega.scale(heatmap.heatmap.scale)().domain(heatmap.heatmap.domain);
         }
     } else {
-        if (heatmap.heatmap.domain != null) {
-            if (heatmap.heatmap.color_scheme != "") {
-                scale = vega.scale(heatmap.heatmap.scale)().domain(heatmap.heatmap.domain).clamp(heatmap.heatmap.clamp).range(vega.scheme(heatmap.heatmap.color_scheme));
-            } else if (!heatmap.heatmap.range == 0) {
-                scale = vega.scale(heatmap.heatmap.scale)().domain(heatmap.heatmap.domain).clamp(heatmap.heatmap.clamp).range(heatmap.heatmap.range);
-            } else {
-                scale = vega.scale(heatmap.heatmap.scale)().domain(heatmap.heatmap.domain).clamp(heatmap.heatmap.clamp);
-            }
+        if (heatmap.heatmap.color_scheme != "") {
+            scale = vega.scale(heatmap.heatmap.scale)().domain(heatmap.heatmap.domain).clamp(heatmap.heatmap.clamp).range(vega.scheme(heatmap.heatmap.color_scheme));
+        } else if (!heatmap.heatmap.range == 0) {
+            scale = vega.scale(heatmap.heatmap.scale)().domain(heatmap.heatmap.domain).clamp(heatmap.heatmap.clamp).range(heatmap.heatmap.range);
         } else {
-            if (heatmap.heatmap.color_scheme != "") {
-                scale = vega.scale(heatmap.heatmap.scale)().clamp(heatmap.heatmap.clamp).range(vega.scheme(heatmap.heatmap.color_scheme));
-            } else if (!heatmap.heatmap.range == 0) {
-                scale = vega.scale(heatmap.heatmap.scale)().clamp(heatmap.heatmap.clamp).range(heatmap.heatmap.range);
-            } else {
-                scale = vega.scale(heatmap.heatmap.scale)().clamp(heatmap.heatmap.clamp);
-            }
+            scale = vega.scale(heatmap.heatmap.scale)().domain(heatmap.heatmap.domain).clamp(heatmap.heatmap.clamp);
         }
     }
 
@@ -270,40 +250,20 @@ function colorizeDetailCard(value, div, heatmap) {
     let scale = null;
 
     if (heatmap.heatmap.scale == "ordinal") {
-        if (heatmap.heatmap.domain != null) {
-            if (heatmap.heatmap.color_scheme != "") {
-                scale = vega.scale(heatmap.heatmap.scale)().domain(heatmap.heatmap.domain).range(vega.scheme(heatmap.heatmap.color_scheme));
-            } else if (!heatmap.heatmap.range.length == 0) {
-                scale = vega.scale(heatmap.heatmap.scale)().domain(heatmap.heatmap.domain).range(heatmap.heatmap.range);
-            } else {
-                scale = vega.scale(heatmap.heatmap.scale)().domain(heatmap.heatmap.domain);
-            }
+        if (heatmap.heatmap.color_scheme != "") {
+            scale = vega.scale(heatmap.heatmap.scale)().domain(heatmap.heatmap.domain).range(vega.scheme(heatmap.heatmap.color_scheme));
+        } else if (!heatmap.heatmap.range.length == 0) {
+            scale = vega.scale(heatmap.heatmap.scale)().domain(heatmap.heatmap.domain).range(heatmap.heatmap.range);
         } else {
-            if (heatmap.heatmap.color_scheme != "") {
-                scale = vega.scale(heatmap.heatmap.scale)().range(vega.scheme(heatmap.heatmap.color_scheme));
-            } else if (!heatmap.heatmap.range.length == 0) {
-                scale = vega.scale(heatmap.heatmap.scale)().range(heatmap.heatmap.range);
-            } else {
-                scale = vega.scale(heatmap.heatmap.scale)();
-            }
+            scale = vega.scale(heatmap.heatmap.scale)().domain(heatmap.heatmap.domain);
         }
     } else {
-        if (heatmap.heatmap.domain != null) {
-            if (heatmap.heatmap.color_scheme != "") {
-                scale = vega.scale(heatmap.heatmap.scale)().domain(heatmap.heatmap.domain).clamp(heatmap.heatmap.clamp).range(vega.scheme(heatmap.heatmap.color_scheme));
-            } else if (!heatmap.heatmap.range == 0) {
-                scale = vega.scale(heatmap.heatmap.scale)().domain(heatmap.heatmap.domain).clamp(heatmap.heatmap.clamp).range(heatmap.heatmap.range);
-            } else {
-                scale = vega.scale(heatmap.heatmap.scale)().domain(heatmap.heatmap.domain).clamp(heatmap.heatmap.clamp);
-            }
+        if (heatmap.heatmap.color_scheme != "") {
+            scale = vega.scale(heatmap.heatmap.scale)().domain(heatmap.heatmap.domain).clamp(heatmap.heatmap.clamp).range(vega.scheme(heatmap.heatmap.color_scheme));
+        } else if (!heatmap.heatmap.range == 0) {
+            scale = vega.scale(heatmap.heatmap.scale)().domain(heatmap.heatmap.domain).clamp(heatmap.heatmap.clamp).range(heatmap.heatmap.range);
         } else {
-            if (heatmap.heatmap.color_scheme != "") {
-                scale = vega.scale(heatmap.heatmap.scale)().clamp(heatmap.heatmap.clamp).range(vega.scheme(heatmap.heatmap.color_scheme));
-            } else if (!heatmap.heatmap.range == 0) {
-                scale = vega.scale(heatmap.heatmap.scale)().clamp(heatmap.heatmap.clamp).range(heatmap.heatmap.range);
-            } else {
-                scale = vega.scale(heatmap.heatmap.scale)().clamp(heatmap.heatmap.clamp);
-            }
+            scale = vega.scale(heatmap.heatmap.scale)().domain(heatmap.heatmap.domain).clamp(heatmap.heatmap.clamp);
         }
     }
 


### PR DESCRIPTION
This PR makes datavzrd pre-calculate the heat map domain if it's numerical. Beforehand configs like the following were not working since the domain needs to be specified for vega:

```yaml
plot:
    heatmap:
        scale: linear
        range:
            - white
            - "#186904" 
```