### PR TITLE
fix: `<a target="_blank">` security vulnerability

### DIFF
--- a/static/datavzrd.js
+++ b/static/datavzrd.js
@@ -213,7 +213,7 @@ function linkUrlColumn(ah, dp_columns, columns, title, link_urls, detail_mode, h
                     link = link.replaceAll(`{${column}}`, table_rows[row][column]);
                 }
                 if (link_urls[0].link.new_window) {
-                    this.innerHTML = `<a href='${link}' target='_blank' >${value}</a>`;
+                    this.innerHTML = `<a href='${link}' target='_blank' rel='noopener noreferrer' >${value}</a>`;
                 } else {
                     this.innerHTML = `<a href='${link}'>${value}</a>`;
                 }
@@ -225,7 +225,7 @@ function linkUrlColumn(ah, dp_columns, columns, title, link_urls, detail_mode, h
                         link = link.replaceAll(`{${column}}`, table_rows[row][column]);
                     }
                     if (l.link.new_window) {
-                        links = `${links}<a class="dropdown-item" href='${link}' target='_blank' >${l.name}</a>`;
+                        links = `${links}<a class="dropdown-item" href='${link}' target='_blank' rel='noopener noreferrer' >${l.name}</a>`;
                     } else {
                         links = `${links}<a class="dropdown-item" href='${link}' >${l.name}</a>`;
                     }

--- a/templates/table.html.tera
+++ b/templates/table.html.tera
@@ -162,7 +162,7 @@
                             </div>
                             <div class="modal-footer">
                                 <span data-toggle="tooltip" data-placement="left" title="Open portable share link. Note that when using the link the row data can temporarily occur (in base64-encoded form) in the server logs of {{webview_host}}.">
-                                    <a href="#" target="_blank" type="button" id="open-url" class="btn btn-primary">Open link</a>
+                                    <a href="#" target="_blank" rel="noopener noreferrer" type="button" id="open-url" class="btn btn-primary">Open link</a>
                                 </span>
 <!--                                <button href="#" type="button" id="bookmark" onclick="browser.bookmark.create({'title': document.title, 'url': $('#open-url').attr('href')})" class="btn btn-primary">-->
 <!--                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-browser-firefox" viewBox="0 0 16 16">-->


### PR DESCRIPTION
Apparently, in old browsers, using just `target="_blank"` to open a web page in a new tab gives access to some parts of the originating tab. See this link for an up to date account of the problem:
https://mathiasbynens.github.io/rel-noopener/

TL;DR: [Just also add ` rel="noopener noreferrer"` to be on the safe side](https://stackoverflow.com/a/17711167/2352071)

Or if you actually need exactly that behaviour (in newer browsers that changed the default), use `rel="opener"`. With regard to this: I am not sure about the change in the template file. Maybe that behavior is somehow wanted there?