### PR TITLE
fix: Render missing empty report when dataset with multiple header rows is empty

### DIFF
--- a/src/render/portable/mod.rs
+++ b/src/render/portable/mod.rs
@@ -88,7 +88,7 @@ impl Renderer for ItemRenderer {
 
             let mut counter_reader = generate_reader()
                 .context(format!("Could not read file with path {:?}", &dataset.path))?;
-            let records_length = counter_reader.records().count();
+            let records_length = counter_reader.records().count() - (dataset.header_rows - 1);
             if records_length > 0 {
                 let linked_tables = get_linked_tables(name, &self.specs)?;
                 // Render plot


### PR DESCRIPTION
This PR should fix a missing empty report file when dataset with multiple header rows is empty.