### PR TITLE
feat: migrate to fancy-regex for regex evaluation (e.g. enabling negative look-ahead/around)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,6 +79,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -306,6 +321,7 @@ dependencies = [
  "derefable",
  "derive-new",
  "dir-assert",
+ "fancy-regex",
  "itertools",
  "lazy_static",
  "log",
@@ -313,7 +329,6 @@ dependencies = [
  "md5",
  "minify-js",
  "ndhistogram",
- "regex",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -375,6 +390,16 @@ name = "either"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+
+[[package]]
+name = "fancy-regex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+dependencies = [
+ "bit-set",
+ "regex",
+]
 
 [[package]]
 name = "flate2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ lz-str = "0.2.1"
 chrono = "0.4"
 ndhistogram = "0.8.0"
 lazy_static = "1.4.0"
-regex = "1.8.1"
+fancy-regex = "0.11.0"
 log = "0.4.17"
 simplelog = "0.12.1"
 minify-js = "=0.5.2" # newer versions generate display issues (see PR #375)

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -8,10 +8,10 @@ use crate::utils::column_type::{classify_table, ColumnType};
 use anyhow::Result;
 use anyhow::{bail, Context};
 use derefable::Derefable;
+use fancy_regex::Regex;
 use itertools::Itertools;
 use lazy_static::lazy_static;
 use log::warn;
-use regex::Regex;
 use serde::Deserialize;
 use serde::Serialize;
 use std::borrow::BorrowMut;
@@ -425,11 +425,12 @@ impl ItemSpecs {
                     .collect_vec()
                     .pop()
                     .unwrap()
+                    .unwrap()
                     .get(1)
                     .unwrap()
                     .as_str()
             };
-            if INDEX_RE.is_match(key) {
+            if INDEX_RE.is_match(key).unwrap() {
                 let index = usize::from_str(get_first_match_group(&INDEX_RE))?;
                 match headers.get(index) {
                     None => {
@@ -451,11 +452,15 @@ impl ItemSpecs {
                         };
                     }
                 }
-            } else if REGEX_RE.is_match(key) {
+            } else if REGEX_RE.is_match(key).unwrap() {
                 let pattern = get_first_match_group(&REGEX_RE);
+                dbg!(pattern);
                 let regex = Regex::new(pattern)
                     .context(format!("Failed to parse provided column regex {key}."))?;
-                for header in headers.iter().filter(|header| regex.is_match(header)) {
+                for header in headers
+                    .iter()
+                    .filter(|header| regex.is_match(header).unwrap())
+                {
                     if indexed_keys
                         .insert(header.to_string(), render_column_specs.clone())
                         .is_some()
@@ -799,18 +804,22 @@ impl AuxDomainColumns {
         let mut new_tick_plot_aux_domain_columns = Vec::new();
         if let Some(columns) = &self.0 {
             for column in columns {
-                if REGEX_RE.is_match(column) {
+                if REGEX_RE.is_match(column).unwrap() {
                     let pattern = REGEX_RE
                         .captures_iter(column)
                         .collect_vec()
                         .pop()
+                        .unwrap()
                         .unwrap()
                         .get(1)
                         .unwrap()
                         .as_str();
                     let regex = Regex::new(pattern)
                         .context(format!("Failed to parse provided column regex {column}."))?;
-                    for header in headers.iter().filter(|header| regex.is_match(header)) {
+                    for header in headers
+                        .iter()
+                        .filter(|header| regex.is_match(header).unwrap())
+                    {
                         new_tick_plot_aux_domain_columns.push(header.to_string());
                     }
                 } else {


### PR DESCRIPTION
This PR makes datavzrd use the `fancy-regex` crate instead of the previously used `regex` crate. This allows using something like [negative look-ahead or other features](https://docs.rs/fancy-regex/latest/fancy_regex/#syntax).