### PR TITLE
fix: Fix hidden table headers when table has additional headers

### DIFF
--- a/static/datavzrd.js
+++ b/static/datavzrd.js
@@ -500,7 +500,8 @@ function render(additional_headers, displayed_columns, table_rows, columns, conf
     $('[data-toggle="popover"]').popover()
     $('[data-toggle="tooltip"]').tooltip()
     if (!config.detail_mode && !config.header_label_length == 0) {
-        $(`table > thead > tr:first-child > th`).each(function() {this.style.setProperty("visibility", "hidden"); this.style.setProperty("border", "none");});
+        $("table > thead > tr:first-child th:first-child").css("visibility", "hidden");
+        $(`table > tbody > tr td:first-child`).each(function() {this.style.setProperty("visibility", "hidden"); this.style.setProperty("border", "none");});
     }
 }
 


### PR DESCRIPTION
This PR fixes a problem where table headers were not shown when the table has additional headers.