### PR TITLE
fix: Show missing table headers

### DIFF
--- a/web/src/datavzrd.js
+++ b/web/src/datavzrd.js
@@ -511,9 +511,6 @@ function render(additional_headers, displayed_columns, table_rows, columns, conf
 
     $('[data-toggle="popover"]').popover()
     $('[data-toggle="tooltip"]').tooltip()
-    if (!config.detail_mode && !config.header_label_length == 0) {
-        $(`table > thead > tr:first-child > th`).each(function() {this.style.setProperty("visibility", "hidden"); this.style.setProperty("border", "none");});
-    }
 }
 
 export function load() {


### PR DESCRIPTION
This PR follows #457 which didn't seem to fully solve the problem.