### PR TITLE
fix: Export embed_search function

### DIFF
--- a/web/src/datavzrd.js
+++ b/web/src/datavzrd.js
@@ -391,7 +391,7 @@ function renderCustomPlotDetailView(value, div, data_function, specs, vega_contr
     vegaEmbed(div, JSON.parse(JSON.stringify(s)), opt);
 }
 
-function embedSearch(index) {
+export function embedSearch(index) {
     var source = `search/column_${index}.html`;
     document.getElementById('search-iframe').setAttribute("src",source);
 }


### PR DESCRIPTION
A quick PR that adds a missing export for a js function.