### PR TITLE
ci: Add git user and email to update webview job

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -84,5 +84,7 @@ jobs:
           run: |
             cd view
             git add static/${{ needs.release-please.outputs.tag_name }}
+            git config --global user.email "github-actions[bot]@users.noreply.github.com"
+            git config --global user.name "github-actions[bot]"
             git commit -m "Release bundle.js for ${{ needs.release-please.outputs.tag_name }}"
             git push


### PR DESCRIPTION
Seems like this was still missing as seen in the last runs error message.