### PR TITLE
feat: Allow custom or custom-path usage with display-mode: detail

### DIFF
--- a/web/src/datavzrd.js
+++ b/web/src/datavzrd.js
@@ -459,6 +459,18 @@ function detailFormatter(index, row) {
                   </div>
                 </div>`;
                 html.push(card);
+            } else if (config.format[key] !== undefined) {
+                var data_function = window[config.format[key]];
+                value = data_function(value, row);
+                var card = `<div class="card">
+                   <div class="card-header">
+                     ${key}
+                   </div>
+                   <div class="card-body">
+                    ${value}
+                   </div>
+                 </div>`;
+                html.push(card);
             } else {
                 var card = `<div class="card">
                    <div class="card-header">


### PR DESCRIPTION
This PR allows the user to use `custom` or `custom-path` with `display-mode: detail` and therefore fixes #527.