### PR TITLE
ci: Fix update webview job

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -87,4 +87,7 @@ jobs:
             git config --global user.email "github-actions[bot]@users.noreply.github.com"
             git config --global user.name "github-actions[bot]"
             git commit -m "Release bundle.js for ${{ needs.release-please.outputs.tag_name }}"
-            git push
+            git push https://$USERNAME:$REPO_KEY@github.com/datavzrd/view.git
+          env:
+            REPO_KEY: ${{secrets.DEPLOYMENT_TOKEN}}
+            USERNAME: github-actions[bot]


### PR DESCRIPTION
A quick PR that should finally fix the update of the webview by giving the commit and push job a token that lets it update the view repository.