### PR TITLE
fix: Show row count badge only for table views

### DIFF
--- a/src/render/portable/mod.rs
+++ b/src/render/portable/mod.rs
@@ -65,6 +65,30 @@ impl Renderer for ItemRenderer {
                         .size(),
                 )
             })
+            .filter(|(view_name, size)| {
+                size == &0
+                    || (self
+                        .specs
+                        .views
+                        .get(view_name)
+                        .unwrap()
+                        .render_plot
+                        .is_none()
+                        && self
+                            .specs
+                            .views
+                            .get(view_name)
+                            .unwrap()
+                            .render_html
+                            .is_none())
+            })
+            .map(|(view_name, size)| {
+                if size == 0 {
+                    (view_name, "empty".to_string())
+                } else {
+                    (view_name, format!("{size} rows"))
+                }
+            })
             .collect();
         for (name, table) in &self.specs.views {
             let out_path = Path::new(path.as_ref()).join(name);
@@ -302,7 +326,7 @@ fn render_page<P: AsRef<Path>>(
     is_single_page: bool,
     has_excel_sheet: bool,
     webview_host: &str,
-    view_sizes: &HashMap<String, usize>,
+    view_sizes: &HashMap<String, String>,
 ) -> Result<()> {
     let mut templates = Tera::default();
     templates.add_raw_template(
@@ -1223,7 +1247,7 @@ fn render_empty_dataset<P: AsRef<Path>>(
     report_name: &str,
     tables: &[String],
     has_excel_sheet: bool,
-    view_sizes: &HashMap<String, usize>,
+    view_sizes: &HashMap<String, String>,
 ) -> Result<()> {
     let mut templates = Tera::default();
     templates.add_raw_template(
@@ -1582,7 +1606,7 @@ fn render_plot_page<P: AsRef<Path>>(
     default_view: &Option<String>,
     report_name: &String,
     has_excel_sheet: bool,
-    view_sizes: &HashMap<String, usize>,
+    view_sizes: &HashMap<String, String>,
 ) -> Result<()> {
     let mut reader = generate_reader(dataset.separator, &dataset.path)
         .context(format!("Could not read file with path {:?}", &dataset.path))?;
@@ -1690,7 +1714,7 @@ fn render_html_page<P: AsRef<Path>>(
     aux_libraries: &Option<Vec<String>>,
     report_name: &String,
     has_excel_sheet: bool,
-    view_sizes: &HashMap<String, usize>,
+    view_sizes: &HashMap<String, String>,
 ) -> Result<()> {
     let mut reader = generate_reader(dataset.separator, &dataset.path)
         .context(format!("Could not read file with path {:?}", &dataset.path))?;

--- a/templates/empty.html.tera
+++ b/templates/empty.html.tera
@@ -22,10 +22,10 @@
                     <li class="breadcrumb-item">
                         <select id="view-selection" title="{{ name }}" data-width="fit" onchange="location = this.value;" data-live-search-placeholder="Filter..." data-dropdown-align-right="true" class="selectpicker" data-style="select-view" data-live-search="true">
                             {% if default_view %}
-                            <option value="../{{ default_view }}/index_1.html" data-content="{{ default_view }} <span class='badge badge-light'>{{ view_sizes[default_view] }} rows</span>">{{ default_view }}</option>
+                            <option value="../{{ default_view }}/index_1.html" data-content="{{ default_view }} {% if view_sizes[default_view] %}<span class='badge badge-light'>{{ view_sizes[default_view] }} rows</span>{% endif %}">{{ default_view }}</option>
                             {% endif %}
                             {% for table in tables | sort %}
-                            <option value="../{{ table }}/index_1.html" data-content="{{ table }} <span class='badge badge-light'>{{ view_sizes[table] }} rows</span>">{{ table }}</option>
+                            <option value="../{{ table }}/index_1.html" data-content="{{ table }} {% if view_sizes[table] %}<span class='badge badge-light'>{{ view_sizes[table] }} rows</span>{% endif %}">{{ table }}</option>
                             {% endfor %}
                         </select>
                     </li>

--- a/templates/html.html.tera
+++ b/templates/html.html.tera
@@ -36,10 +36,10 @@
                         <li class="breadcrumb-item">
                             <select id="view-selection" title="{{ name }}" data-width="fit" onchange="location = this.value;" data-live-search-placeholder="Filter..." class="selectpicker" data-style="select-view" data-live-search="true">
                                 {% if default_view %}
-                                <option value="../{{ default_view }}/index_1.html" data-content="{{ default_view }} <span class='badge badge-light'>{{ view_sizes[default_view] }} rows</span>">{{ default_view }}</option>
+                                <option value="../{{ default_view }}/index_1.html" data-content="{{ default_view }} {% if view_sizes[default_view] %}<span class='badge badge-light'>{{ view_sizes[default_view] }} rows</span>{% endif %}">{{ default_view }}</option>
                                 {% endif %}
                                 {% for table in tables | sort %}
-                                <option value="../{{ table }}/index_1.html" data-content="{{ table }} <span class='badge badge-light'>{{ view_sizes[table] }} rows</span>">{{ table }}</option>
+                                <option value="../{{ table }}/index_1.html" data-content="{{ table }} {% if view_sizes[table] %}<span class='badge badge-light'>{{ view_sizes[table] }} rows</span>{% endif %}">{{ table }}</option>
                                 {% endfor %}
                             </select>
                         </li>

--- a/templates/plot.html.tera
+++ b/templates/plot.html.tera
@@ -31,10 +31,10 @@
                         <li class="breadcrumb-item">
                             <select id="view-selection" title="{{ name }}" data-width="fit" onchange="location = this.value;" data-live-search-placeholder="Filter..." class="selectpicker" data-style="select-view" data-live-search="true">
                                 {% if default_view %}
-                                <option value="../{{ default_view }}/index_1.html" data-content="{{ default_view }} <span class='badge badge-light'>{{ view_sizes[default_view] }} rows</span>">{{ default_view }}</option>
+                                <option value="../{{ default_view }}/index_1.html" data-content="{{ default_view }} {% if view_sizes[default_view] %}<span class='badge badge-light'>{{ view_sizes[default_view] }} rows</span>{% endif %}">{{ default_view }}</option>
                                 {% endif %}
                                 {% for table in tables | sort %}
-                                <option value="../{{ table }}/index_1.html" data-content="{{ table }} <span class='badge badge-light'>{{ view_sizes[table] }} rows</span>">{{ table }}</option>
+                                <option value="../{{ table }}/index_1.html" data-content="{{ table }} {% if view_sizes[table] %}<span class='badge badge-light'>{{ view_sizes[table] }} rows</span>{% endif %}">{{ table }}</option>
                                 {% endfor %}
                             </select>
                         </li>

--- a/templates/table.html.tera
+++ b/templates/table.html.tera
@@ -44,10 +44,10 @@
                         <li class="breadcrumb-item">
                             <select id="view-selection" title="{{ name }}" data-width="fit" onchange="location = this.value;" data-live-search-placeholder="Filter..." class="selectpicker" data-style="select-view" data-live-search="true">
                                 {% if default_view %}
-                                <option value="../{{ default_view }}/index_1.html" data-content="{{ default_view }} <span class='badge badge-light'>{{ view_sizes[default_view] }} rows</span>">{{ default_view }}</option>
+                                <option value="../{{ default_view }}/index_1.html" data-content="{{ default_view }} {% if view_sizes[default_view] %}<span class='badge badge-light'>{{ view_sizes[default_view] }} rows</span>{% endif %}">{{ default_view }}</option>
                                 {% endif %}
                                 {% for table in tables | sort %}
-                                <option value="../{{ table }}/index_1.html" data-content="{{ table }} <span class='badge badge-light'>{{ view_sizes[table] }} rows</span>">{{ table }}</option>
+                                <option value="../{{ table }}/index_1.html" data-content="{{ table }} {% if view_sizes[table] %}<span class='badge badge-light'>{{ view_sizes[table] }} rows</span>{% endif %}">{{ table }}</option>
                                 {% endfor %}
                             </select>
                         </li>


### PR DESCRIPTION
This PR makes datavzrd only show the row count badge if the view is either empty or it is a table view. Row counts for plot or html views could be confusing for the user.