### PR TITLE
fix: Remove duplicated word rows

### DIFF
--- a/templates/table.html.tera
+++ b/templates/table.html.tera
@@ -44,10 +44,10 @@
                         <li class="breadcrumb-item">
                             <select id="view-selection" title="{{ name }}" data-width="fit" onchange="location = this.value;" data-live-search-placeholder="Filter..." class="selectpicker" data-style="select-view" data-live-search="true">
                                 {% if default_view %}
-                                <option value="../{{ default_view }}/index_1.html" data-content="{{ default_view }} {% if view_sizes[default_view] %}<span class='badge badge-light'>{{ view_sizes[default_view] }} rows</span>{% endif %}">{{ default_view }}</option>
+                                <option value="../{{ default_view }}/index_1.html" data-content="{{ default_view }} {% if view_sizes[default_view] %}<span class='badge badge-light'>{{ view_sizes[default_view] }}</span>{% endif %}">{{ default_view }}</option>
                                 {% endif %}
                                 {% for table in tables | sort %}
-                                <option value="../{{ table }}/index_1.html" data-content="{{ table }} {% if view_sizes[table] %}<span class='badge badge-light'>{{ view_sizes[table] }} rows</span>{% endif %}">{{ table }}</option>
+                                <option value="../{{ table }}/index_1.html" data-content="{{ table }} {% if view_sizes[table] %}<span class='badge badge-light'>{{ view_sizes[table] }}</span>{% endif %}">{{ table }}</option>
                                 {% endfor %}
                             </select>
                         </li>


### PR DESCRIPTION
Just a quick PR that fixes a small issue where the word `rows` was duplicated in the menu after #535.