### PR TITLE
feat: Add color option to tick and bar plots

### DIFF
--- a/.examples/example-config.yaml
+++ b/.examples/example-config.yaml
@@ -107,6 +107,11 @@ views:
               domain:
                 - 1
                 - 10
+              color:
+                scale: linear
+                range:
+                  - red
+                  - green
         Rated:
           plot-view-legend: true
           plot:

--- a/README.md
+++ b/README.md
@@ -278,11 +278,12 @@ views:
 
 `ticks` defines the attributes of a [tick-plot](https://vega.github.io/vega-lite/docs/tick.html) for numeric values.
 
-| keyword            | explanation                                                                                                                                                                                                                                                                                                             |
-|--------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| scale              | Defines the [scale](https://vega.github.io/vega-lite/docs/scale.html) of the tick plot                                                                                                                                                                                                                                  |
-| domain             | Defines the domain of the tick plot. If not present datavzrd will automatically use the minimum and maximum values for the domain                                                                                                                                                                                       |
-| aux-domain-columns | Allows to specify a list of other columns that will be additionally used to determine the domain of the tick plot. Regular expression (e.g. `"regex('prob:.+')"` for matching all columns starting with `prob:`) are also supported as well as range expressions (e.g. `range(5, 10)` for the 5th column to 9th column).  |
+| keyword            | explanation                                                                                                                                                                                                                                                                                                              |
+|--------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| scale              | Defines the [scale](https://vega.github.io/vega-lite/docs/scale.html) of the tick plot                                                                                                                                                                                                                                   |
+| domain             | Defines the domain of the tick plot. If not present datavzrd will automatically use the minimum and maximum values for the domain                                                                                                                                                                                        |
+| aux-domain-columns | Allows to specify a list of other columns that will be additionally used to determine the domain of the tick plot. Regular expression (e.g. `"regex('prob:.+')"` for matching all columns starting with `prob:`) are also supported as well as range expressions (e.g. `range(5, 10)` for the 5th column to 9th column). |
+| [color](#color)    | Defines the color of the tick plot                                                                                                                                                                                                                                                                                       |
 
 ### heatmap
 
@@ -304,11 +305,24 @@ views:
 
 `bars` defines the attributes of a [bar-plot](https://vega.github.io/vega-lite/docs/bar.html) for numeric values.
 
-| keyword            | explanation                                                                                                                                                                                                                       |
-|--------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| scale              | Defines the [scale](https://vega.github.io/vega-lite/docs/scale.html) of the bar plot                                                                                                                                             |
-| domain             | Defines the domain of the bar plot. If not present datavzrd will automatically use the minimum and maximum values for the domain                                                                                                  |
+| keyword            | explanation                                                                                                                                                                                                                         |
+|--------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| scale              | Defines the [scale](https://vega.github.io/vega-lite/docs/scale.html) of the bar plot                                                                                                                                               |
+| domain             | Defines the domain of the bar plot. If not present datavzrd will automatically use the minimum and maximum values for the domain                                                                                                    |
 | aux-domain-columns | Allows to specify a list of other columns that will be additionally used to determine the domain of the bar plot. Regular expression (e.g. `"regex('prob:.+')"` for matching all columns starting with `prob:`) are also supported. |
+| [color](#color)    | Defines the color of the bar plot                                                                                                                                                                                                   |
+
+### color
+
+`color` defines the attributes of a color scale definition for tick and bar plots
+
+| keyword    | explanation                                                                                                                                                        |
+|------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| scale      | Defines the [scale](https://vega.github.io/vega-lite/docs/scale.html) of the tick or bar plot                                                                      |
+| domain     | Defines the domain of the color scale of the tick or bar plot. If not present datavzrd will automatically use the minimum and maximum values for the domain        |
+| domain-mid | Defines a mid point of the domain. The argument is passed on straight to the [vega-lite domain defintion](https://vega.github.io/vega-lite/docs/scale.html#domain) |
+| range      | Defines the color range of the tick or bar plot as a list                                                                                                          |
+
 
 ## Authors
 

--- a/src/render/portable/mod.rs
+++ b/src/render/portable/mod.rs
@@ -1534,6 +1534,7 @@ fn render_tick_plot(
     context.insert("maximum", &max);
     context.insert("field", &title);
     context.insert("scale_type", &tick_plot.scale_type);
+    context.insert("color_definition", &tick_plot.color);
 
     Ok(templates.render("tick_plot.vl.tera", &context)?)
 }
@@ -1591,6 +1592,7 @@ fn render_bar_plot(
     context.insert("maximum", &max);
     context.insert("field", &title);
     context.insert("scale_type", &bar_plot.scale_type);
+    context.insert("color_definition", &bar_plot.color);
 
     Ok(templates.render("bar_plot.vl.tera", &context)?)
 }

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -816,6 +816,20 @@ pub(crate) struct TickPlot {
     pub(crate) domain: Option<Vec<f32>>,
     #[serde(default)]
     pub(crate) aux_domain_columns: AuxDomainColumns,
+    #[serde(default)]
+    pub(crate) color: Option<ColorDefinition>,
+}
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[serde(rename_all(deserialize = "kebab-case"), deny_unknown_fields)]
+pub(crate) struct ColorDefinition {
+    #[serde(default, rename = "scale")]
+    pub(crate) scale_type: ScaleType,
+    #[serde(default, rename = "range")]
+    pub(crate) color_range: Vec<String>,
+    #[serde(default)]
+    pub(crate) domain: Option<Vec<String>>,
+    #[serde(default)]
+    pub(crate) domain_mid: Option<f32>,
 }
 
 fn default_clamp() -> bool {
@@ -854,6 +868,8 @@ pub(crate) struct BarPlot {
     pub(crate) domain: Option<Vec<f32>>,
     #[serde(default)]
     pub(crate) aux_domain_columns: AuxDomainColumns,
+    #[serde(default)]
+    pub(crate) color: Option<ColorDefinition>,
 }
 
 #[derive(Default, Deserialize, Serialize, Debug, Clone, PartialEq, Copy)]
@@ -1645,6 +1661,7 @@ mod tests {
                 "birth_d".to_string(),
                 "birth_y".to_string(),
             ])),
+            color: None,
         };
         let expected_plot = PlotSpec {
             tick_plot: Some(expected_ticks),

--- a/templates/bar_plot.vl.tera
+++ b/templates/bar_plot.vl.tera
@@ -9,11 +9,33 @@
             "scale": {"type": "{{ scale_type }}","domain": [{{ minimum | json_encode }}, {{ maximum | json_encode }}]},
             "axis": null
         },
-        "y": {"value": 0, "scale": {"domain": [0, 1]}},
-        "color": {"value": "#6baed6"}
+        "y": {"value": 0, "scale": {"domain": [0, 1]}}
     },
     "layer": [
-        {"mark": {"type":"bar", "height": 12, "yOffset": 11}},
+        {
+            "mark": {
+                "type":"bar",
+                "height": 12,
+                "yOffset": 11
+            }{% if color_definition %},
+            "encoding": {
+                "color": {
+                    "scale": {
+                        "type": "{{ color_definition.scale }}",
+                        "range": {{ color_definition.range | json_encode }},
+                        "domain": {% if color_definition.domain %}{{ color_definition.domain | json_encode }}{% else %}[{{ minimum | json_encode }}, {{ maximum | json_encode }}]{% endif %}
+                        {% if color_definition.domain_mid %}, "domainMid": {{ color_definition.domain_mid }}{% endif %}
+                    },
+                    "field": "{{ field }}",
+                    "legend": null,
+                    "type": "quantitative"
+                }
+            }{% else %}
+            "encoding": {
+                "color": {"value": "#6baed6"}
+            }
+            {% endif %}
+        },
         {
         "mark": {"type": "text", "yOffset": 11, "xOffset": 12},
         "encoding": {"x": {"value": 0}, "text": {"field": "{{ field }}"}, "color": {"value": "black"}}

--- a/templates/tick_plot.vl.tera
+++ b/templates/tick_plot.vl.tera
@@ -18,7 +18,22 @@
         "y": {"value": 0, "scale": {"domain": [0, 1]}}
     },
     "layer": [
-        {"mark": "tick"},
+        {
+            "mark": "tick"{% if color_definition %},
+            "encoding": {
+                "color": {
+                    "scale": {
+                        "type": "{{ color_definition.scale }}",
+                        "range": {{ color_definition.range | json_encode }},
+                        "domain": {% if color_definition.domain %}{{ color_definition.domain | json_encode }}{% else %}[{{ minimum | json_encode }}, {{ maximum | json_encode }}]{% endif %}
+                        {% if color_definition.domain_mid %}, "domainMid": {{ color_definition.domain_mid }}{% endif %}
+                    },
+                    "field": "{{ field }}",
+                    "legend": null,
+                    "type": "quantitative"
+                }
+            }{% endif %}
+        },
         {
         "mark": {"type": "text", "yOffset": -8, "xOffset": 12},
         "encoding": {"x": {"value": 0}, "text": {"field": "{{ field }}"}}


### PR DESCRIPTION
This PR allows to define color mappings for tick and bar plots like the following one:

```yaml
imdbRating:
  precision: 1
  plot:
    bars:
      scale: linear
      domain:
        - 1
        - 10
      color:
        scale: linear
        range:
          - red
          - green
```

This PR closes #586.