### PR TITLE
feat: Add padding to description if it is small

### DIFF
--- a/templates/table.html.tera
+++ b/templates/table.html.tera
@@ -81,7 +81,7 @@
                         <span class="sr-only">Loading...</span>
                     </div>
                 </div>
-                <div class="col-md-12 table-container" style="margin-top: 15px;">
+                <div id="table-container" class="col-md-12 table-container" style="margin-top: 15px;">
                     <table id="table" class="table" data-classes="table">
                     </table>
                 </div>

--- a/web/src/datavzrd.js
+++ b/web/src/datavzrd.js
@@ -24,6 +24,9 @@ function renderMarkdownDescription() {
     });
     converter.setFlavor('github');
     innerDescription.innerHTML = converter.makeHtml(innerDescription.dataset.markdown);
+    if (innerDescription.offsetHeight < window.screen.height/3) {
+        $('#table-container').css('padding-top', innerDescription.offsetHeight - 25);
+    }
 }
 
 function precision_formatter(precision, value) {


### PR DESCRIPTION
This PR makes datavzrd pad the description height of the table in case it is smaller than one third of the window height.