### PR TITLE
refactor: Use dataset functions instead of explicitly generating new reader

### DIFF
--- a/src/render/portable/mod.rs
+++ b/src/render/portable/mod.rs
@@ -128,10 +128,8 @@ impl Renderer for ItemRenderer {
                     .from_path(&dataset.path)
             };
 
-            let mut counter_reader = generate_reader()
-                .context(format!("Could not read file with path {:?}", &dataset.path))?;
-            let records_length = counter_reader.records().count() - (dataset.header_rows - 1);
-            if records_length > 0 {
+            let records_length = dataset.size();
+            if !dataset.is_empty() {
                 let linked_tables = get_linked_tables(name, &self.specs)?;
                 // Render plot
                 if table.render_plot.is_some() {

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -1816,6 +1816,18 @@ mod tests {
     }
 
     #[test]
+    fn test_dataset_empty() {
+        let empty_dataset = DatasetSpecs {
+            path: PathBuf::from("tests/data/empty_table.csv"),
+            separator: ',',
+            header_rows: 4,
+            links: None,
+            offer_excel: false,
+        };
+        assert!(empty_dataset.is_empty());
+    }
+
+    #[test]
     fn test_dataset_unique_column_values() {
         let config = ItemsSpec::from_file(".examples/example-config.yaml").unwrap();
         let unique_column_values = config


### PR DESCRIPTION
This PR does some minor refactoring and adds a test case for the `is_empty()` method of the DatasetSpec struct and therefore should fix #417 for now.