### PR TITLE
build: Improve and fix build script

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -13,7 +13,7 @@ fn main() {
         ])
         .current_dir(env!("CARGO_MANIFEST_DIR"))
         .status()
-        .expect("failed to copy web/ to OUT_DIR/web/");
+        .expect("failed to copy web/ into OUT_DIR/");
 
     let work_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap()).join("web/");
 

--- a/build.rs
+++ b/build.rs
@@ -1,12 +1,13 @@
 use std::path::PathBuf;
 
 fn main() {
+    println!("cargo:rerun-if-changed=web/");
     std::process::Command::new("cp")
         .args([
             "-r",
+            "-v",
             "web/",
             PathBuf::from(std::env::var("OUT_DIR").unwrap())
-                .join("web/")
                 .to_str()
                 .unwrap(),
         ])


### PR DESCRIPTION
This PR fixes a problem when copying the web directory within the build script that caused problems when recompiling datavzrd. It also manually tells cargo to rebuild only if the web directory changed.