### PR TITLE
build: Fix web path causing build problems on OS X

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -6,7 +6,7 @@ fn main() {
         .args([
             "-r",
             "-v",
-            "web/",
+            "web",
             PathBuf::from(std::env::var("OUT_DIR").unwrap())
                 .to_str()
                 .unwrap(),


### PR DESCRIPTION
This PR fixes a build problem on OS X.