### PR TITLE
perf: Use lz-string compression for search dialogs

### DIFF
--- a/templates/search_dialog.html.tera
+++ b/templates/search_dialog.html.tera
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <title>datavzrd report</title>
+    <meta charset="UTF-8">
     <link rel="stylesheet" type="text/css" href="../../static/bootstrap.min.css">
     <link rel="stylesheet" type="text/css" href="../../static/bootstrap-table.min.css">
 </head>
@@ -9,27 +10,14 @@
 <body>
 <script src="../../static/bundle.js"></script>
 <script>
+    const search_data = {{ data | safe }};
+    const table_title = "{{ title }}";
     datavzrd.load_search();
 </script>
 <div class="container-fluid">
     <div class="row">
         <div class="col-12">
-            <table class="table table-hover" data-toggle="table" data-classes="table table-hover" data-search="true" style="width: 100%; position: center">
-                <thead>
-                <tr>
-                    <th>page</th>
-                    <th>{{ title }}</th>
-                </tr>
-                </thead>
-                <tbody>
-                {% for record in records %}
-                <tr>
-                    <td><a target="_parent" href="../index_{{ record.1 }}.html?highlight={{ record.2 }}" style="display: table-cell">{{ record.1 }}</a></td>
-                    <td>{{ record.0 }}</td>
-                </tr>
-                {% endfor %}
-                </tbody>
-            </table>
+            <table id="search-table"></table>
         </div>
     </div>
 </div>

--- a/web/src/datavzrd.js
+++ b/web/src/datavzrd.js
@@ -1111,7 +1111,6 @@ export function load_search() {
                 title: row[0]
             })
         }
-        console.log(table_data);
         $('#search-table').bootstrapTable({
             columns: [
                 { field: "page", title: "page" },

--- a/web/src/datavzrd.js
+++ b/web/src/datavzrd.js
@@ -607,7 +607,7 @@ export function load() {
                 }
 
                 // Add static search if not single page mode
-                if (!config.is_single_page && !config.additional_colums[column]) {
+                if (!config.is_single_page && !config.additional_colums[column] && !config.column_config[column].is_float) {
                     title += ` <a class="sym" data-toggle="modal" onclick="datavzrd.embedSearch(${config.columns.indexOf(column)})" data-target="#search"><svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-search" fill="currentColor" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M10.442 10.442a1 1 0 0 1 1.415 0l3.85 3.85a1 1 0 0 1-1.414 1.415l-3.85-3.85a1 1 0 0 1 0-1.415z"/><path fill-rule="evenodd" d="M6.5 12a5.5 5.5 0 1 0 0-11 5.5 5.5 0 0 0 0 11zM13 6.5a6.5 6.5 0 1 1-13 0 6.5 6.5 0 0 1 13 0z"/></svg></a>`;
                 }
 
@@ -1101,7 +1101,26 @@ $(document).click(function (event) {
 export function load_search() {
     $(document).ready(function() {
         window.$ = window.jQuery = require("jquery");
-        $('.table').bootstrapTable({
+        window['bootstrap-table'] = require('bootstrap-table');
+        const decompressed = JSON.parse(LZString.decompressFromUTF16(search_data));
+        let table_data = [];
+        for (var i = 0; i < decompressed.length; i++) {
+            var row = decompressed[i];
+            table_data.push({
+                page: `<a target="_parent" href="../index_${row[1]}.html?highlight=${row[2]}" style="display: table-cell">${row[1]}</a>`,
+                title: row[0]
+            })
+        }
+        console.log(table_data);
+        $('#search-table').bootstrapTable({
+            columns: [
+                { field: "page", title: "page" },
+                { field: "title", title: table_title }
+            ],
+            data: table_data,
+            search: true
+        });
+        $('#search-table').bootstrapTable({
             onPostHeader: function () {
                 $(".search-input").focus();
             }


### PR DESCRIPTION
This PR should highly improve report storage use with using lz-string compression on the search dialog data and therefore closes #628.