### PR TITLE
perf: Use single modal for histograms of all columns

### DIFF
--- a/templates/table.html.tera
+++ b/templates/table.html.tera
@@ -115,19 +115,17 @@
                 {% endif %}
                 </div>
             </div>
-            <!-- Modal -->
-            {% for title in titles %}
-            <div class="modal fade" id="modal_{{ loop.index0 }}" tabindex="-1" role="dialog" aria-hidden="true">
+            <div class="modal fade" id="histogram_modal" tabindex="-1" role="dialog" aria-hidden="true">
                 <div class="modal-dialog modal-dialog-centered modal-lg" role="document">
                     <div class="modal-content">
                         <div class="modal-header">
-                            <h5 class="modal-title">{{ title }}</h5>
+                            <h5 class="modal-title" id="histogram-modal-title"></h5>
                             <button type="button" class="close" data-dismiss="modal" aria-label="Close">
                                 <span aria-hidden="true">&times;</span>
                             </button>
                         </div>
                         <div class="modal-body">
-                            <div id="plot_{{ loop.index0 }}" style="width: 100%; height: 300px; border:none;">
+                            <div id="histogram-plot" style="width: 100%; height: 300px; border:none;">
                             </div>
                         </div>
                         <div class="modal-footer">
@@ -136,7 +134,7 @@
                     </div>
                 </div>
             </div>
-            {% endfor %}<div class="modal fade bd-example-modal-lg" tabindex="-1" role="dialog" aria-labelledby="myLargeModalLabelqr" id="qr-modal" aria-hidden="true">
+            <div class="modal fade bd-example-modal-lg" tabindex="-1" role="dialog" aria-labelledby="myLargeModalLabelqr" id="qr-modal" aria-hidden="true">
                 <div class="modal-dialog modal-lg id="modal-dialog-qr">
                     <div class="modal-content">
                         <div class="modal-header">

--- a/web/src/datavzrd.js
+++ b/web/src/datavzrd.js
@@ -421,10 +421,11 @@ export function embedSearch(index) {
 }
 
 export function embedHistogram(show_plot, index, plot) {
+    $("#histogram-modal-title").text(config.columns[index]);
     if (show_plot) {
-        vegaEmbed(`#plot_${index}`, plot);
+        vegaEmbed('#histogram-plot', plot);
     } else {
-        document.getElementById(`plot_${index}`).innerHTML = '<p>No reasonable plot possible.</p>';
+        document.getElementById('histogram-plot').innerHTML = '<p>No reasonable plot possible.</p>';
     }
 }
 function addNumClass(dp_num, ah, detail_mode, config) {
@@ -634,7 +635,7 @@ export function load() {
                 }
 
                 // Add histogram button
-                let histogram_icon = ` <a class="sym" data-toggle="modal" data-target="#modal_${config.columns.indexOf(column)}" onclick="datavzrd.embedHistogram(show_plot_${config.columns.indexOf(column)}, ${config.columns.indexOf(column)}, plot_${config.columns.indexOf(column)})"><svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-bar-chart-fill" fill="currentColor" xmlns="http://www.w3.org/2000/svg"><rect width="4" height="5" x="1" y="10" rx="1"/><rect width="4" height="9" x="6" y="6" rx="1"/><rect width="4" height="14" x="11" y="1" rx="1"/></svg></a>`;
+                let histogram_icon = ` <a class="sym" data-toggle="modal" data-target="#histogram_modal" onclick="datavzrd.embedHistogram(show_plot_${config.columns.indexOf(column)}, ${config.columns.indexOf(column)}, plot_${config.columns.indexOf(column)})"><svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-bar-chart-fill" fill="currentColor" xmlns="http://www.w3.org/2000/svg"><rect width="4" height="5" x="1" y="10" rx="1"/><rect width="4" height="9" x="6" y="6" rx="1"/><rect width="4" height="14" x="11" y="1" rx="1"/></svg></a>`;
                 if (!config.additional_colums[column]) {
                     title += histogram_icon;
                 }


### PR DESCRIPTION
This PR should massively improve report storage by reducing the number of modals used to display histograms to 1 instead of of the number of displayed columns. For the test report this reduces the size of each html page from `20kb` to `11kb`.