### PR TITLE
perf: Use JSONM for compression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -490,6 +490,7 @@ dependencies = [
  "derive-new",
  "fancy-regex",
  "itertools 0.12.1",
+ "jsonm",
  "lazy_static",
  "log",
  "lz-str",
@@ -797,6 +798,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonm"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef5e879b2495af9898cd6bb696fe5aa6380b345971c4758da7923179739ac9b"
+dependencies = [
+ "regex",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1522,6 +1534,7 @@ version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
 dependencies = [
+ "indexmap",
  "itoa",
  "ryu",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,5 @@ minify-html = "0.15.0"
 simple_excel_writer = "0.2"
 slug = "0.1.5"
 md5 = "0.7.0"
+jsonm = "0.2.0"
+

--- a/src/render/portable/mod.rs
+++ b/src/render/portable/mod.rs
@@ -1,6 +1,5 @@
 mod plot;
 pub(crate) mod utils;
-
 use crate::render::portable::plot::get_min_max;
 use crate::render::portable::plot::render_plots;
 use crate::render::portable::utils::get_column_labels;
@@ -15,12 +14,12 @@ use crate::utils::column_index::ColumnIndex;
 use crate::utils::column_position;
 use crate::utils::column_type::IsNa;
 use crate::utils::column_type::{classify_table, ColumnType};
+use crate::utils::compress::compress;
 use crate::utils::row_address::RowAddressFactory;
 use anyhow::Result;
 use anyhow::{bail, Context as AnyhowContext};
 use chrono::{DateTime, Local};
 use itertools::Itertools;
-use lz_str::compress_to_utf16;
 use serde::Serialize;
 use serde_json::{json, Value};
 use std::cmp::max;
@@ -331,12 +330,12 @@ fn render_page<P: AsRef<Path>>(
                 .unwrap()
             })
             .collect_vec();
-        Some(compress_to_utf16(&json!(linkouts).to_string()))
+        Some(compress(json!(linkouts))?)
     } else {
         None
     };
 
-    let compressed_data = compress_to_utf16(&json!(data).to_string());
+    let compressed_data = compress(json!(data))?;
 
     let local: DateTime<Local> = Local::now();
 
@@ -1356,7 +1355,7 @@ fn render_search_dialogs<P: AsRef<Path>>(
                 .map(|(row, address)| (row, address.page + 1, address.row))
                 .collect_vec();
 
-            let compressed_data = compress_to_utf16(&json!(records).to_string());
+            let compressed_data = compress(json!(records))?;
 
             let mut templates = Tera::default();
             templates.add_raw_template(
@@ -1665,7 +1664,7 @@ fn render_plot_page<P: AsRef<Path>>(
 
     let local: DateTime<Local> = Local::now();
 
-    let compressed_data = compress_to_utf16(&json!(records).to_string());
+    let compressed_data = compress(json!(records))?;
 
     context.insert("data", &json!(compressed_data).to_string());
     context.insert("description", &item_spec.description);
@@ -1828,7 +1827,7 @@ fn render_plot_page_with_multiple_datasets<P: AsRef<Path>>(
 
     let local: DateTime<Local> = Local::now();
 
-    let compressed_data = compress_to_utf16(&json!(data).to_string());
+    let compressed_data = compress(json!(data))?;
 
     context.insert("datasets", &json!(compressed_data).to_string());
     context.insert("description", &item_spec.description);

--- a/src/utils/compress.rs
+++ b/src/utils/compress.rs
@@ -1,0 +1,11 @@
+use anyhow::Result;
+use jsonm::packer::{PackOptions, Packer};
+use lz_str::compress_to_utf16;
+use serde_json::{json, Value};
+
+pub(crate) fn compress(data: Value) -> Result<String> {
+    let mut packer = Packer::new();
+    let options = PackOptions::new();
+    let jsonm = packer.pack(&data, &options)?;
+    Ok(compress_to_utf16(&json!(jsonm).to_string()))
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -3,6 +3,7 @@ use anyhow::Result;
 
 pub(crate) mod column_index;
 pub(crate) mod column_type;
+pub(crate) mod compress;
 pub(crate) mod row_address;
 
 /// Returns the index of the given column of a csv header

--- a/web/src/datavzrd.js
+++ b/web/src/datavzrd.js
@@ -589,7 +589,8 @@ export function load() {
         if ($("#collapseDescription").length > 0) {
             renderMarkdownDescription();
         }
-        var decompressed = JSON.parse(LZString.decompressFromUTF16(data));
+
+        let decompressed = decompress(data);
 
         for (row of decompressed) {
             var row_with_keys = Object.fromEntries(config.columns.map((k, i) => [k, row[i]]));
@@ -672,7 +673,7 @@ export function load() {
 
         if (linkouts != null) {
             bs_table_cols.push({field: 'linkouts', title: '', formatter: function(value){ return value }});
-            var decompressed_linkouts = JSON.parse(LZString.decompressFromUTF16(linkouts));
+            var decompressed_linkouts = decompress(linkouts);
         }
 
         if (config.webview_controls) {
@@ -1113,10 +1114,10 @@ export function load_table(specs, data, multiple_datasets) {
     }
     if (multiple_datasets) {
         specs.datasets = {};
-        specs.datasets = JSON.parse(LZString.decompressFromUTF16(data));
+        specs.datasets = decompress(data);
     } else {
         specs.data = {};
-        specs.data.values = JSON.parse(LZString.decompressFromUTF16(data));
+        specs.data.values = decompress(data);
     }
     if (specs.width == "container") { $("#vis").css("width", "100%"); }
     vegaEmbed('#vis', specs);
@@ -1141,7 +1142,7 @@ export function load_search() {
     $(document).ready(function() {
         window.$ = window.jQuery = require("jquery");
         window['bootstrap-table'] = require('bootstrap-table');
-        const decompressed = JSON.parse(LZString.decompressFromUTF16(search_data));
+        let decompressed = decompress(search_data);
         let table_data = [];
         for (var i = 0; i < decompressed.length; i++) {
             var row = decompressed[i];
@@ -1197,4 +1198,11 @@ export function toggle_line_numbers() {
         line_numbers("table-cell");
     }
     LINE_NUMBERS = !LINE_NUMBERS;
+}
+
+function decompress(data) {
+    var decompressed = JSON.parse(LZString.decompressFromUTF16(data));
+    const unpacker = new jsonm.Unpacker();
+    decompressed = unpacker.unpack(decompressed);
+    return decompressed
 }


### PR DESCRIPTION
This PR adds JSONM compression that somehow wasn't used. All compression is now outsourced into separate functions for Rust as well as for the javascript library.  