### PR TITLE
build: Use turbopack as webpack replacement

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -24,8 +24,9 @@ fn main() {
         .expect("failed to execute webpack");
 
     std::process::Command::new("npx")
-        .arg("webpack")
+        .arg("turbo")
+        .arg("build")
         .current_dir(work_dir.to_str().expect("failed to get work dir"))
         .status()
-        .expect("failed to execute webpack");
+        .expect("failed to execute turbo build");
 }

--- a/web/package.json
+++ b/web/package.json
@@ -4,7 +4,7 @@
   "description": "Web components for datavzrd",
   "main": "datavzrd.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "build": "turbo build"
   },
   "author": "Johannes Köster <johannes.koester@tu-dortmund.de>, Felix Wiegand <felix.wiegand@tu-dortmund.de>",
   "license": "MIT",
@@ -24,9 +24,8 @@
     "d3": "^7.8.5"
   },
   "devDependencies": {
-    "webpack": "^5.86.0",
-    "webpack-cli": "^5.1.4",
     "css-loader": "^7.1.2",
-    "style-loader": "^3.3.1"
+    "style-loader": "^3.3.1",
+    "@turbo/pack": "^2.0.0"
   }
 }

--- a/web/turbo.config.js
+++ b/web/turbo.config.js
@@ -1,6 +1,7 @@
 const path = require('path');
+const { defineConfig } = require('@turbo/pack');
 
-module.exports = {
+module.exports = defineConfig({
     entry: './src/datavzrd.js',
     mode: 'development',
     devtool: 'source-map',
@@ -17,4 +18,4 @@ module.exports = {
             },
         ],
     },
-};
+});


### PR DESCRIPTION
This PR replaces webpack with the faster turbopack which is written in rust.