### PR TITLE
fix: Remove null being displayed when table doesnt have a description

### DIFF
--- a/web/src/page.js
+++ b/web/src/page.js
@@ -12,6 +12,9 @@ export function render_html_contents() {
                 </div>
             </div>
         </div>`;
+    if (!config.description) {
+        description_html = "";
+    }
     let inner_pagination_html = "";
     if (CURRENT_PAGE > 1) {
         if (CURRENT_PAGE !== 2) {


### PR DESCRIPTION
This PR fixes an issue where `null` was being displayed as the description if there was none.