### PR TITLE
fix: Escape description string

### DIFF
--- a/src/render/portable/mod.rs
+++ b/src/render/portable/mod.rs
@@ -32,7 +32,7 @@ use std::io::Write;
 use std::option::Option::Some;
 use std::path::Path;
 use std::str::FromStr;
-use tera::{Context, Tera};
+use tera::{Context, Tera, escape_html};
 use thiserror::Error;
 use typed_builder::TypedBuilder;
 
@@ -1065,7 +1065,7 @@ impl JavascriptConfig {
             tables: sorted_tables,
             default_view: default_view.to_owned(),
             has_excel_sheet,
-            description: description.map(|s| s.to_string()),
+            description: description.map(|s| escape_html(s)),
             report_name: report_name.to_owned(),
             time: local.format("%a %b %e %T %Y").to_string(),
             version: env!("CARGO_PKG_VERSION").to_string(),


### PR DESCRIPTION
This PR escapes the description string with tera `escape_html` method.