### PR TITLE
fix: Fix popover z-index for numeric search widget

### DIFF
--- a/web/style/datavzrd.css
+++ b/web/style/datavzrd.css
@@ -351,3 +351,7 @@ footer {
     z-index: 2;
     right: calc(50% - 50px);
 }
+
+.popover {
+    z-index: 2 !important;
+}


### PR DESCRIPTION
This PR addresses an issue with the filter widget where the tooltip of the brush filter for numeric values was behind the filter widget.