### PR TITLE
feat: Add new subcommand for suggesting configurations based on files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,7 +330,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
+ "strsim 0.11.1",
 ]
 
 [[package]]
@@ -510,6 +510,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2 1.0.86",
+ "quote 1.0.36",
+ "strsim 0.10.0",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
+dependencies = [
+ "darling_core",
+ "quote 1.0.36",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "dashmap"
 version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -563,6 +598,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "serde_with",
  "serde_yaml",
  "simple_excel_writer",
  "simplelog",
@@ -1056,6 +1092,12 @@ checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -2239,6 +2281,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
+dependencies = [
+ "serde",
+ "serde_with_macros",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
+dependencies = [
+ "darling",
+ "proc-macro2 1.0.86",
+ "quote 1.0.36",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2342,6 +2406,12 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ thiserror = "2"
 readervzrd = "0.1.1"
 typed-builder = "0.20"
 serde_yaml = "0.8" # https://github.com/AlexanderThaller/format_serde_error/pull/23
+serde_with = { version = "1.9.0", features = ["macros"] }
 derive-new = "0.7"
 itertools = "0.14.0"
 tera = "1.20.0"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -59,6 +59,20 @@ pub enum Command {
         #[arg(long)]
         org: Option<String>,
     },
+    /// Suggest a configuration file based on the given tabular input files.
+    Suggest {
+        /// List of paths to input files
+        #[arg(required = true, short, long, value_parser)]
+        files: Vec<PathBuf>,
+
+        /// Separators for the corresponding input files (e.g., comma for CSV, tab for TSV)
+        #[arg(required = true, short, long, value_parser, value_name = "SEPARATORS")]
+        separators: Vec<char>,
+
+        /// Name of the report
+        #[arg(short, long, default_value = "Datavzrd Report")]
+        name: String,
+    },
 }
 
 #[derive(Error, Debug)]
@@ -68,4 +82,7 @@ pub enum CliError {
 
     #[error("`<CONFIG>` is required when no subcommand is used.")]
     MissingConfig,
+
+    #[error("Given separators don not match the number of input files.")]
+    MismatchedSeparators,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ pub(crate) mod publish;
 pub(crate) mod render;
 pub(crate) mod spec;
 pub(crate) mod spells;
+mod suggest;
 pub(crate) mod utils;
 
 fn main() -> Result<()> {
@@ -35,6 +36,16 @@ fn main() -> Result<()> {
         }) => {
             let repo = publish::Repository::new(repo_name, org, report_path)?;
             repo.publish()?;
+        }
+        Some(Command::Suggest {
+            files,
+            separators,
+            name,
+        }) => {
+            if files.len() != separators.len() {
+                bail!(CliError::MismatchedSeparators);
+            }
+            suggest::suggest(files, separators, name)?;
         }
         None => {
             let config = opt

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -19,6 +19,7 @@ use crate::spells::SpellSpec;
 use format_serde_error::SerdeError;
 use serde::Deserialize;
 use serde::Serialize;
+use serde_with::skip_serializing_none;
 use std::borrow::BorrowMut;
 use std::collections::HashMap;
 use std::fmt::Debug;
@@ -29,7 +30,8 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use thiserror::Error;
 
-#[derive(Derefable, Deserialize, Debug, Clone, PartialEq)]
+#[skip_serializing_none]
+#[derive(Derefable, Deserialize, Serialize, Debug, Clone, PartialEq)]
 #[serde(rename_all(deserialize = "kebab-case"), deny_unknown_fields)]
 pub(crate) struct ItemsSpec {
     #[serde(default, rename = "name")]
@@ -341,7 +343,7 @@ impl ItemsSpec {
     }
 }
 
-fn default_single_page_threshold() -> usize {
+pub(crate) fn default_single_page_threshold() -> usize {
     20000_usize
 }
 
@@ -349,7 +351,7 @@ fn default_separator() -> char {
     char::from_str(",").unwrap()
 }
 
-fn default_page_size() -> usize {
+pub(crate) fn default_page_size() -> usize {
     20
 }
 
@@ -368,8 +370,8 @@ fn default_render_table() -> Option<RenderTableSpecs> {
 fn default_links() -> Option<HashMap<String, LinkSpec>> {
     Some(HashMap::new())
 }
-
-#[derive(Deserialize, Debug, Clone, PartialEq, Default)]
+#[skip_serializing_none]
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Default)]
 #[serde(rename_all(deserialize = "kebab-case"), deny_unknown_fields)]
 pub(crate) struct DatasetSpecs {
     pub(crate) path: PathBuf,
@@ -427,7 +429,8 @@ impl DatasetSpecs {
     }
 }
 
-#[derive(Deserialize, Debug, Clone, PartialEq)]
+#[skip_serializing_none]
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
 #[serde(rename_all(deserialize = "kebab-case"), deny_unknown_fields)]
 pub(crate) struct ItemSpecs {
     #[serde(default)]
@@ -487,7 +490,8 @@ impl ItemSpecs {
     }
 }
 
-#[derive(Deserialize, Debug, Clone, PartialEq)]
+#[skip_serializing_none]
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
 #[serde(rename_all(deserialize = "kebab-case"), deny_unknown_fields)]
 pub(crate) struct RenderTableSpecs {
     #[serde(default)]
@@ -498,7 +502,7 @@ pub(crate) struct RenderTableSpecs {
     pub(crate) headers: Option<HashMap<u32, HeaderSpecs>>,
 }
 
-#[derive(Deserialize, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
 #[serde(rename_all(deserialize = "kebab-case"), deny_unknown_fields)]
 pub(crate) struct AdditionalColumnSpec {
     #[serde(default = "default_value_function")]
@@ -515,7 +519,8 @@ fn default_value_function() -> String {
     String::from("function(row) { return '' }")
 }
 
-#[derive(Deserialize, Debug, Clone, PartialEq)]
+#[skip_serializing_none]
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
 #[serde(rename_all(deserialize = "kebab-case"), deny_unknown_fields)]
 pub(crate) struct HeaderSpecs {
     #[serde(default)]
@@ -687,7 +692,8 @@ fn default_precision() -> u32 {
     2_u32
 }
 
-#[derive(Deserialize, Debug, Clone, PartialEq)]
+#[skip_serializing_none]
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
 #[serde(rename_all(deserialize = "kebab-case"), deny_unknown_fields)]
 pub(crate) struct RenderColumnSpec {
     #[serde(default)]
@@ -905,7 +911,8 @@ impl BarPlot {
     }
 }
 
-#[derive(Deserialize, Debug, Clone, PartialEq)]
+#[skip_serializing_none]
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
 #[serde(rename_all(deserialize = "kebab-case"), deny_unknown_fields)]
 pub(crate) struct RenderPlotSpec {
     #[serde(default, rename = "spec")]
@@ -927,19 +934,19 @@ impl RenderPlotSpec {
     }
 }
 
-#[derive(Deserialize, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
 #[serde(rename_all(deserialize = "kebab-case"), deny_unknown_fields)]
 pub(crate) struct RenderHtmlSpec {
     pub(crate) script_path: String,
 }
 
-#[derive(Deserialize, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
 #[serde(rename_all(deserialize = "kebab-case"), deny_unknown_fields)]
 pub(crate) struct RenderImgSpec {
     pub(crate) path: String,
 }
 
-#[derive(Deserialize, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
 #[serde(rename_all(deserialize = "kebab-case"), deny_unknown_fields)]
 pub(crate) struct LinkSpec {
     #[serde(default)]
@@ -978,7 +985,8 @@ impl CustomPlot {
     }
 }
 
-#[derive(Deserialize, Debug, Clone, PartialEq)]
+#[skip_serializing_none]
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
 #[serde(rename_all(deserialize = "kebab-case"), deny_unknown_fields)]
 pub(crate) struct PlotSpec {
     #[serde(rename = "ticks")]
@@ -1023,6 +1031,7 @@ fn default_clamp() -> bool {
     true
 }
 
+#[skip_serializing_none]
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
 #[serde(rename_all(deserialize = "kebab-case"), deny_unknown_fields)]
 pub(crate) struct Heatmap {

--- a/src/spells.rs
+++ b/src/spells.rs
@@ -6,12 +6,12 @@ use pyo3::prelude::*;
 use pyo3::types::IntoPyDict;
 use pyo3::types::PyModule;
 use reqwest::blocking::get;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
 
-#[derive(Deserialize, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
 #[serde(rename_all(deserialize = "kebab-case"), deny_unknown_fields)]
 pub(crate) struct SpellSpec {
     pub(crate) url: String,

--- a/src/suggest.rs
+++ b/src/suggest.rs
@@ -1,0 +1,100 @@
+use crate::spec::{
+    default_page_size, default_single_page_threshold, AuxDomainColumns, DatasetSpecs, Heatmap,
+    ItemSpecs, ItemsSpec, PlotSpec, RenderColumnSpec, RenderTableSpecs, ScaleType,
+};
+use crate::utils::column_type::ColumnType;
+use anyhow::Result;
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+pub(crate) fn suggest(files: Vec<PathBuf>, separator: Vec<char>, name: String) -> Result<()> {
+    let mut items_spec = ItemsSpec {
+        report_name: name,
+        datasets: HashMap::new(),
+        default_view: None,
+        max_in_memory_rows: default_single_page_threshold(),
+        views: HashMap::new(),
+        aux_libraries: None,
+        webview_controls: false,
+    };
+    for (file, sep) in files.iter().zip(separator.iter()) {
+        let dataset = DatasetSpecs {
+            path: file.to_owned(),
+            separator: sep.to_owned(),
+            header_rows: 1,
+            links: None,
+            offer_excel: false,
+        };
+        let dataset_name = file.file_name().unwrap().to_str().unwrap().to_string();
+        items_spec
+            .datasets
+            .insert(dataset_name.to_string(), dataset.clone());
+        let column_types = crate::utils::column_type::classify_table(&dataset)?;
+        let mut columns = HashMap::new();
+        for (column_name, column_type) in column_types.iter() {
+            let render_column_spec = match column_type {
+                ColumnType::None => RenderColumnSpec::default(),
+                ColumnType::String => RenderColumnSpec {
+                    plot: Some(PlotSpec {
+                        tick_plot: None,
+                        heatmap: Some(Heatmap {
+                            vega_type: None,
+                            scale_type: ScaleType::Ordinal,
+                            clamp: false,
+                            color_scheme: "category20".to_string(),
+                            color_range: Default::default(),
+                            domain: None,
+                            domain_mid: None,
+                            aux_domain_columns: AuxDomainColumns(None),
+                            custom_content: None,
+                        }),
+                        bar_plot: None,
+                    }),
+                    ..RenderColumnSpec::default()
+                },
+                ColumnType::Integer | ColumnType::Float => RenderColumnSpec {
+                    plot: Some(PlotSpec {
+                        tick_plot: None,
+                        heatmap: Some(Heatmap {
+                            vega_type: None,
+                            scale_type: ScaleType::Linear,
+                            clamp: false,
+                            color_scheme: "viridis".to_string(),
+                            color_range: Default::default(),
+                            domain: None,
+                            domain_mid: None,
+                            aux_domain_columns: AuxDomainColumns(None),
+                            custom_content: None,
+                        }),
+                        bar_plot: None,
+                    }),
+                    ..RenderColumnSpec::default()
+                },
+            };
+            columns.insert(column_name.to_string(), render_column_spec);
+        }
+        let render_table = RenderTableSpecs {
+            columns,
+            additional_columns: None,
+            headers: None,
+        };
+        let item_spec = ItemSpecs {
+            hidden: false,
+            dataset: Some(dataset_name.to_string()),
+            datasets: None,
+            page_size: default_page_size(),
+            single_page_page_size: default_page_size(),
+            description: None,
+            render_table: Some(render_table),
+            render_plot: None,
+            render_html: None,
+            render_img: None,
+            max_in_memory_rows: None,
+            spell: None,
+        };
+        items_spec.views.insert(dataset_name.to_string(), item_spec);
+    }
+    let mut stdout = std::io::stdout();
+    serde_yaml::to_writer(&mut stdout, &items_spec)?;
+    Ok(())
+}


### PR DESCRIPTION
This pull request introduces a new feature for suggesting configuration files based on input files.

### New Feature:
* Added a new `Suggest` command to the CLI for generating configuration files from tabular input files. This includes handling input files and separators, and generating a configuration report.