### PR TITLE
fix: Fix wrong case for configs generated with datavzrd suggest

### DIFF
--- a/src/spec.rs
+++ b/src/spec.rs
@@ -30,7 +30,7 @@ use std::str::FromStr;
 use thiserror::Error;
 
 #[derive(Derefable, Deserialize, Debug, Clone, PartialEq)]
-#[serde(rename_all(deserialize = "kebab-case"), deny_unknown_fields)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub(crate) struct ItemsSpec {
     #[serde(default, rename = "name")]
     pub(crate) report_name: String,
@@ -370,7 +370,7 @@ fn default_links() -> Option<HashMap<String, LinkSpec>> {
 }
 
 #[derive(Deserialize, Debug, Clone, PartialEq, Default)]
-#[serde(rename_all(deserialize = "kebab-case"), deny_unknown_fields)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub(crate) struct DatasetSpecs {
     pub(crate) path: PathBuf,
     #[serde(default = "default_separator")]
@@ -428,7 +428,7 @@ impl DatasetSpecs {
 }
 
 #[derive(Deserialize, Debug, Clone, PartialEq)]
-#[serde(rename_all(deserialize = "kebab-case"), deny_unknown_fields)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub(crate) struct ItemSpecs {
     #[serde(default)]
     pub(crate) hidden: bool,
@@ -488,7 +488,7 @@ impl ItemSpecs {
 }
 
 #[derive(Deserialize, Debug, Clone, PartialEq)]
-#[serde(rename_all(deserialize = "kebab-case"), deny_unknown_fields)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub(crate) struct RenderTableSpecs {
     #[serde(default)]
     pub(crate) columns: HashMap<String, RenderColumnSpec>,
@@ -499,7 +499,7 @@ pub(crate) struct RenderTableSpecs {
 }
 
 #[derive(Deserialize, Debug, Clone, PartialEq)]
-#[serde(rename_all(deserialize = "kebab-case"), deny_unknown_fields)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub(crate) struct AdditionalColumnSpec {
     #[serde(default = "default_value_function")]
     pub(crate) value: String,
@@ -516,7 +516,7 @@ fn default_value_function() -> String {
 }
 
 #[derive(Deserialize, Debug, Clone, PartialEq)]
-#[serde(rename_all(deserialize = "kebab-case"), deny_unknown_fields)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub(crate) struct HeaderSpecs {
     #[serde(default)]
     pub(crate) label: Option<String>,
@@ -688,7 +688,7 @@ fn default_precision() -> u32 {
 }
 
 #[derive(Deserialize, Debug, Clone, PartialEq)]
-#[serde(rename_all(deserialize = "kebab-case"), deny_unknown_fields)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub(crate) struct RenderColumnSpec {
     #[serde(default)]
     pub(crate) optional: Option<bool>,
@@ -791,7 +791,7 @@ impl RenderColumnSpec {
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
-#[serde(rename_all(deserialize = "kebab-case"))]
+#[serde(rename_all = "kebab-case")]
 pub(crate) struct LinkToUrlSpec {
     #[serde(flatten)]
     pub(crate) entries: HashMap<String, LinkToUrlSpecEntry>,
@@ -799,7 +799,7 @@ pub(crate) struct LinkToUrlSpec {
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
-#[serde(rename_all(deserialize = "kebab-case"), deny_unknown_fields)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub(crate) struct LinkToUrlSpecEntry {
     url: String,
     #[serde(default = "default_new_window")]
@@ -906,7 +906,7 @@ impl BarPlot {
 }
 
 #[derive(Deserialize, Debug, Clone, PartialEq)]
-#[serde(rename_all(deserialize = "kebab-case"), deny_unknown_fields)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub(crate) struct RenderPlotSpec {
     #[serde(default, rename = "spec")]
     pub(crate) schema: Option<String>,
@@ -928,19 +928,19 @@ impl RenderPlotSpec {
 }
 
 #[derive(Deserialize, Debug, Clone, PartialEq)]
-#[serde(rename_all(deserialize = "kebab-case"), deny_unknown_fields)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub(crate) struct RenderHtmlSpec {
     pub(crate) script_path: String,
 }
 
 #[derive(Deserialize, Debug, Clone, PartialEq)]
-#[serde(rename_all(deserialize = "kebab-case"), deny_unknown_fields)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub(crate) struct RenderImgSpec {
     pub(crate) path: String,
 }
 
 #[derive(Deserialize, Debug, Clone, PartialEq)]
-#[serde(rename_all(deserialize = "kebab-case"), deny_unknown_fields)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub(crate) struct LinkSpec {
     #[serde(default)]
     pub(crate) column: String,
@@ -953,7 +953,7 @@ pub(crate) struct LinkSpec {
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
-#[serde(rename_all(deserialize = "kebab-case"), deny_unknown_fields)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub(crate) struct CustomPlot {
     #[serde(default, rename = "data")]
     pub(crate) plot_data: String,
@@ -979,7 +979,7 @@ impl CustomPlot {
 }
 
 #[derive(Deserialize, Debug, Clone, PartialEq)]
-#[serde(rename_all(deserialize = "kebab-case"), deny_unknown_fields)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub(crate) struct PlotSpec {
     #[serde(rename = "ticks")]
     pub(crate) tick_plot: Option<TickPlot>,
@@ -989,7 +989,7 @@ pub(crate) struct PlotSpec {
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
-#[serde(rename_all(deserialize = "kebab-case"), deny_unknown_fields)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub(crate) struct TickPlot {
     #[serde(default, rename = "scale")]
     pub(crate) scale_type: ScaleType,
@@ -1001,7 +1001,7 @@ pub(crate) struct TickPlot {
     pub(crate) color: Option<ColorDefinition>,
 }
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
-#[serde(rename_all(deserialize = "kebab-case"), deny_unknown_fields)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub(crate) struct ColorDefinition {
     #[serde(default, rename = "scale")]
     pub(crate) scale_type: ScaleType,
@@ -1024,7 +1024,7 @@ fn default_clamp() -> bool {
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
-#[serde(rename_all(deserialize = "kebab-case"), deny_unknown_fields)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub(crate) struct Heatmap {
     #[serde(default, rename = "type")]
     pub(crate) vega_type: Option<VegaType>,
@@ -1091,7 +1091,7 @@ lazy_static! {
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
-#[serde(rename_all(deserialize = "kebab-case"), deny_unknown_fields)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub(crate) struct BarPlot {
     #[serde(default, rename = "scale")]
     pub(crate) scale_type: ScaleType,

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -32,7 +32,7 @@ use thiserror::Error;
 
 #[skip_serializing_none]
 #[derive(Derefable, Deserialize, Serialize, Debug, Clone, PartialEq)]
-#[serde(rename_all(deserialize = "kebab-case"), deny_unknown_fields)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub(crate) struct ItemsSpec {
     #[serde(default, rename = "name")]
     pub(crate) report_name: String,
@@ -372,7 +372,7 @@ fn default_links() -> Option<HashMap<String, LinkSpec>> {
 }
 #[skip_serializing_none]
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Default)]
-#[serde(rename_all(deserialize = "kebab-case"), deny_unknown_fields)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub(crate) struct DatasetSpecs {
     pub(crate) path: PathBuf,
     #[serde(default = "default_separator")]
@@ -431,7 +431,7 @@ impl DatasetSpecs {
 
 #[skip_serializing_none]
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
-#[serde(rename_all(deserialize = "kebab-case"), deny_unknown_fields)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub(crate) struct ItemSpecs {
     #[serde(default)]
     pub(crate) hidden: bool,
@@ -492,7 +492,7 @@ impl ItemSpecs {
 
 #[skip_serializing_none]
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
-#[serde(rename_all(deserialize = "kebab-case"), deny_unknown_fields)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub(crate) struct RenderTableSpecs {
     #[serde(default)]
     pub(crate) columns: HashMap<String, RenderColumnSpec>,
@@ -503,7 +503,7 @@ pub(crate) struct RenderTableSpecs {
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
-#[serde(rename_all(deserialize = "kebab-case"), deny_unknown_fields)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub(crate) struct AdditionalColumnSpec {
     #[serde(default = "default_value_function")]
     pub(crate) value: String,
@@ -521,7 +521,7 @@ fn default_value_function() -> String {
 
 #[skip_serializing_none]
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
-#[serde(rename_all(deserialize = "kebab-case"), deny_unknown_fields)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub(crate) struct HeaderSpecs {
     #[serde(default)]
     pub(crate) label: Option<String>,
@@ -694,7 +694,7 @@ fn default_precision() -> u32 {
 
 #[skip_serializing_none]
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
-#[serde(rename_all(deserialize = "kebab-case"), deny_unknown_fields)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub(crate) struct RenderColumnSpec {
     #[serde(default)]
     pub(crate) optional: Option<bool>,
@@ -797,7 +797,7 @@ impl RenderColumnSpec {
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
-#[serde(rename_all(deserialize = "kebab-case"))]
+#[serde(rename_all = "kebab-case")]
 pub(crate) struct LinkToUrlSpec {
     #[serde(flatten)]
     pub(crate) entries: HashMap<String, LinkToUrlSpecEntry>,
@@ -805,7 +805,7 @@ pub(crate) struct LinkToUrlSpec {
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
-#[serde(rename_all(deserialize = "kebab-case"), deny_unknown_fields)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub(crate) struct LinkToUrlSpecEntry {
     url: String,
     #[serde(default = "default_new_window")]
@@ -913,7 +913,7 @@ impl BarPlot {
 
 #[skip_serializing_none]
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
-#[serde(rename_all(deserialize = "kebab-case"), deny_unknown_fields)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub(crate) struct RenderPlotSpec {
     #[serde(default, rename = "spec")]
     pub(crate) schema: Option<String>,
@@ -935,19 +935,19 @@ impl RenderPlotSpec {
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
-#[serde(rename_all(deserialize = "kebab-case"), deny_unknown_fields)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub(crate) struct RenderHtmlSpec {
     pub(crate) script_path: String,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
-#[serde(rename_all(deserialize = "kebab-case"), deny_unknown_fields)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub(crate) struct RenderImgSpec {
     pub(crate) path: String,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
-#[serde(rename_all(deserialize = "kebab-case"), deny_unknown_fields)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub(crate) struct LinkSpec {
     #[serde(default)]
     pub(crate) column: String,
@@ -960,7 +960,7 @@ pub(crate) struct LinkSpec {
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
-#[serde(rename_all(deserialize = "kebab-case"), deny_unknown_fields)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub(crate) struct CustomPlot {
     #[serde(default, rename = "data")]
     pub(crate) plot_data: String,
@@ -987,7 +987,7 @@ impl CustomPlot {
 
 #[skip_serializing_none]
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
-#[serde(rename_all(deserialize = "kebab-case"), deny_unknown_fields)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub(crate) struct PlotSpec {
     #[serde(rename = "ticks")]
     pub(crate) tick_plot: Option<TickPlot>,
@@ -997,7 +997,7 @@ pub(crate) struct PlotSpec {
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
-#[serde(rename_all(deserialize = "kebab-case"), deny_unknown_fields)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub(crate) struct TickPlot {
     #[serde(default, rename = "scale")]
     pub(crate) scale_type: ScaleType,
@@ -1009,7 +1009,7 @@ pub(crate) struct TickPlot {
     pub(crate) color: Option<ColorDefinition>,
 }
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
-#[serde(rename_all(deserialize = "kebab-case"), deny_unknown_fields)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub(crate) struct ColorDefinition {
     #[serde(default, rename = "scale")]
     pub(crate) scale_type: ScaleType,
@@ -1033,7 +1033,7 @@ fn default_clamp() -> bool {
 
 #[skip_serializing_none]
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
-#[serde(rename_all(deserialize = "kebab-case"), deny_unknown_fields)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub(crate) struct Heatmap {
     #[serde(default, rename = "type")]
     pub(crate) vega_type: Option<VegaType>,
@@ -1100,7 +1100,7 @@ lazy_static! {
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
-#[serde(rename_all(deserialize = "kebab-case"), deny_unknown_fields)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub(crate) struct BarPlot {
     #[serde(default, rename = "scale")]
     pub(crate) scale_type: ScaleType,


### PR DESCRIPTION
This pull request simplifies the serde attribute usage in the `src/spec.rs` file by removing the unnecessary `deserialize` parameter from the `rename_all` attribute. This change ensures consistency and reduces redundancy across multiple struct definitions.

Fixes #864