### PR TITLE
feat: Add warning for potential floats using comma

### DIFF
--- a/src/utils/column_type.rs
+++ b/src/utils/column_type.rs
@@ -27,7 +27,13 @@ impl ColumnType {
                 (true, false, ColumnType::None)
                 | (true, _, ColumnType::Float)
                 | (true, false, ColumnType::Integer) => ColumnType::Float,
-                (false, false, _) | (_, _, ColumnType::String) => ColumnType::String,
+                (false, false, _) | (_, _, ColumnType::String) => {
+                    let replaced_comma = value.replace(',', '.');
+                    if f64::from_str(replaced_comma).is_ok() {
+                        warn!("The value '{value}' contains a comma and will not be parsed as a float. Consider using '.' for decimal points.")
+                    }
+                    ColumnType::String
+                }
                 (false, true, _) => unreachable!(),
             };
         }

--- a/src/utils/column_type.rs
+++ b/src/utils/column_type.rs
@@ -1,5 +1,6 @@
 use crate::spec::DatasetSpecs;
 use anyhow::Result;
+use log::warn;
 use std::collections::HashMap;
 use std::iter::FromIterator;
 use std::str::FromStr;

--- a/src/utils/column_type.rs
+++ b/src/utils/column_type.rs
@@ -29,8 +29,8 @@ impl ColumnType {
                 | (true, _, ColumnType::Float)
                 | (true, false, ColumnType::Integer) => ColumnType::Float,
                 (false, false, _) | (_, _, ColumnType::String) => {
-                    let replaced_comma = value.replace(',', '.');
-                    if f64::from_str(replaced_comma).is_ok() {
+                    let replaced_comma = value.replace(",", ".");
+                    if f64::from_str(&replaced_comma).is_ok() {
                         warn!("The value '{value}' contains a comma and will not be parsed as a float. Consider using '.' for decimal points.")
                     }
                     ColumnType::String


### PR DESCRIPTION
This pull request includes a few changes to the `src/utils/column_type.rs` file to improve logging and handle specific cases where values contain commas. The most important changes include adding a new import for the `log::warn` function and modifying the `impl ColumnType` to log a warning when a potential float value containing a comma is encountered.