### PR TITLE
feat: Add new pills keyword

### DIFF
--- a/.examples/example-config.yaml
+++ b/.examples/example-config.yaml
@@ -87,6 +87,8 @@ views:
     dataset: movies
     render-table:
       columns:
+        Director:
+          ellipsis: 40
         Genre:
           plot:
             pills:

--- a/.examples/example-config.yaml
+++ b/.examples/example-config.yaml
@@ -88,7 +88,10 @@ views:
     render-table:
       columns:
         Genre:
-          ellipsis: 15
+          plot:
+            pills:
+              separator: ","
+              color-scheme: category20
         imdbID:
           link-to-url:
             IMDB:

--- a/src/spells.rs
+++ b/src/spells.rs
@@ -187,6 +187,7 @@ mod tests {
                     custom_content: None,
                 }),
                 bar_plot: None,
+                pills: None,
             }),
             custom_plot: None,
             ellipsis: None,

--- a/src/suggest.rs
+++ b/src/suggest.rs
@@ -49,6 +49,7 @@ pub(crate) fn suggest(files: Vec<PathBuf>, separator: Vec<char>, name: String) -
                             custom_content: None,
                         }),
                         bar_plot: None,
+                        pills: None,
                     }),
                     ..RenderColumnSpec::default()
                 },
@@ -67,6 +68,7 @@ pub(crate) fn suggest(files: Vec<PathBuf>, separator: Vec<char>, name: String) -
                             custom_content: None,
                         }),
                         bar_plot: None,
+                        pills: None,
                     }),
                     ..RenderColumnSpec::default()
                 },


### PR DESCRIPTION
This PR adds a new `pills` option for heatmap like visualizations for cells containing multiple values split by a delimiter like `,`.