### PR TITLE
feat: Add --entry option for datavzrd publish command

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -58,6 +58,10 @@ pub enum Command {
         /// Optional: Specify the organization for the repo
         #[arg(long)]
         org: Option<String>,
+
+        /// Optional: Specify the entry point for the report
+        #[arg(long)]
+        entry: Option<PathBuf>,
     },
     /// Suggest a configuration file based on the given tabular input files.
     Suggest {

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,8 +34,9 @@ fn main() -> Result<()> {
             repo_name,
             report_path,
             org,
+            entry,
         }) => {
-            let repo = publish::Repository::new(repo_name, org, report_path)?;
+            let repo = publish::Repository::new(repo_name, org, report_path, entry)?;
             repo.publish()?;
         }
         Some(Command::Suggest {

--- a/src/publish.rs
+++ b/src/publish.rs
@@ -70,7 +70,7 @@ impl Repository {
         if let Some(entry) = &self.entry {
             if *entry != PathBuf::from("index.html") {
                 let destination = self.path.join("deployment").join("index.html");
-                let redirect = format!("<!DOCTYPE html><html><head></head><body><script>window.location.href = {};</script></body></html>", entry.display());
+                let redirect = format!("<!DOCTYPE html><html><head></head><body><script>window.location.href = \"{}\";</script></body></html>", entry.display());
                 fs::write(&destination, redirect).context("Failed to write entry file")?;
             }
         }

--- a/src/publish.rs
+++ b/src/publish.rs
@@ -10,19 +10,31 @@ pub(crate) struct Repository {
     name: String,
     owner: String,
     path: PathBuf,
+    entry: Option<PathBuf>,
 }
 
 impl Repository {
-    pub(crate) fn new(name: String, owner: Option<String>, path: PathBuf) -> Result<Self> {
+    pub(crate) fn new(
+        name: String,
+        owner: Option<String>,
+        path: PathBuf,
+        entry: Option<PathBuf>,
+    ) -> Result<Self> {
         if !path.exists() {
             bail!(PublishError::PathDoesNotExist(path));
         }
         match owner {
-            Some(owner) => Ok(Self { name, owner, path }),
+            Some(owner) => Ok(Self {
+                name,
+                owner,
+                path,
+                entry,
+            }),
             None => Ok(Self {
                 name,
                 owner: user()?,
                 path,
+                entry,
             }),
         }
     }
@@ -52,6 +64,17 @@ impl Repository {
 
     pub fn repository_name(&self) -> String {
         format!("{}/{}", self.owner, self.name)
+    }
+
+    fn entry(&self) -> Result<()> {
+        if let Some(entry) = &self.entry {
+            if *entry != PathBuf::from("index.html") {
+                let destination = self.path.join("deployment").join("index.html");
+                let redirect = format!("<!DOCTYPE html><html><head></head><body><script>window.location.href = {};</script></body></html>", entry.display());
+                fs::write(&destination, redirect).context("Failed to write entry file")?;
+            }
+        }
+        Ok(())
     }
 
     fn clone_repository(&self) -> Result<()> {
@@ -124,6 +147,8 @@ impl Repository {
                     .context(format!("Failed to copy file: {:?}", entry_path))?;
             }
         }
+
+        self.entry()?;
 
         let deployment_dir = deployment_path.clone();
 

--- a/src/publish.rs
+++ b/src/publish.rs
@@ -248,6 +248,7 @@ mod tests {
             "datavzrd".to_string(),
             Some("datavzrd".to_string()),
             PathBuf::from("."),
+            None,
         )?;
         let output = repo.exists()?;
         assert!(output);
@@ -260,6 +261,7 @@ mod tests {
             "nonexistent_repo".to_string(),
             Some("owner".to_string()),
             PathBuf::from("."),
+            None,
         )?;
         let output = repo.exists()?;
         assert!(!output);


### PR DESCRIPTION
This pull request introduces a new feature to specify an entry point for the report in the `publish` command. The changes primarily involve adding an optional `entry` parameter to various structs and methods, and implementing logic to handle this new parameter. Fixes #874 

### New Feature: Entry Point for Report

* [`src/cli.rs`](diffhunk://#diff-b2812f19576dd53d0c35b107a322f58a00fce6977f4b5976e1961853982af3ccR61-R64): Added an optional `entry` parameter to the `publish` command in the `Command` enum.
* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR37-R39): Updated the `publish` command handling to pass the new `entry` parameter to the `Repository` struct.
* `src/publish.rs`: 
  * Added an `entry` field to the `Repository` struct and updated the `new` method to accept this parameter.
  * Implemented the `entry` method to handle the entry point logic, creating a redirect file if the entry is different from `index.html`.
  * Called the `entry` method during the repository publishing process to ensure the entry point is handled correctly.