### PR TITLE
feat: Support the `ellipsis` setting on pill plots.

### DIFF
--- a/.examples/example-config.yaml
+++ b/.examples/example-config.yaml
@@ -94,6 +94,7 @@ views:
             pills:
               separator: ","
               color-scheme: category20
+              ellipsis: 5
         imdbID:
           link-to-url:
             IMDB:

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -1012,6 +1012,8 @@ pub(crate) struct PillsSpec {
     pub(crate) color_range: ColorRange,
     #[serde(default)]
     pub(crate) domain: Option<Vec<String>>,
+    #[serde(default)]
+    pub(crate) ellipsis: Option<u32>,
 }
 
 fn default_pill_separator() -> String {

--- a/web/src/datavzrd.js
+++ b/web/src/datavzrd.js
@@ -5,13 +5,12 @@ import showdownKatex from 'showdown-katex';
 import jsonm from 'jsonm';
 import * as vega from "vega";
 import vegaEmbed from 'vega-embed';
-import vegalite from 'vega-lite';
 import QRCode from 'qrcode';
 import * as d3 from "d3";
 import 'bootstrap';
 import 'bootstrap-table/src/bootstrap-table.js';
 import 'bootstrap-select';
-import { documentToSVG, elementToSVG, inlineResources, formatXML } from 'dom-to-svg';
+import {elementToSVG} from 'dom-to-svg';
 import {render_html_contents, render_plot_size_controls} from "./page";
 import '../style/bootstrap.min.css';
 import '../style/bootstrap-table.min.css';
@@ -224,11 +223,8 @@ function renderPill(value, color, ellipsis) {
   }
 }
 
-function renderPills(ah, columns, pills, detail_mode, header_label_length) {
-    let index = get_index(pills.title, columns, detail_mode, header_label_length);
-    let row = 0;
-    var table_rows = $("#table").bootstrapTable('getData', {useCurrentPage: "true"});
-    let heatmap = {
+function pillsToHeatmap(pills) {
+    return {
         heatmap: {
             scale: "ordinal",
             domain: pills.pills.domain,
@@ -237,7 +233,14 @@ function renderPills(ah, columns, pills, detail_mode, header_label_length) {
             clamp: true,
             "custom-content": undefined
         }
-    }
+    };
+}
+
+function renderPills(ah, columns, pills, detail_mode, header_label_length) {
+    let index = get_index(pills.title, columns, detail_mode, header_label_length);
+    let row = 0;
+    var table_rows = $("#table").bootstrapTable('getData', {useCurrentPage: "true"});
+    let heatmap = pillsToHeatmap(pills);
     let scale = datavzrdScale(heatmap);
 
     $(`table > tbody > tr td:nth-child(${index})`).each(
@@ -257,26 +260,18 @@ function renderPills(ah, columns, pills, detail_mode, header_label_length) {
 }
 
 function renderDetailPills(value, div, pills) {
-    let heatmap = {
-        heatmap: {
-            scale: "ordinal",
-            domain: pills.pills.domain,
-            range: pills.pills.range,
-            "color-scheme": pills.pills["color-scheme"],
-            clamp: true,
-            "custom-content": undefined
-        }
-    }
+    let heatmap = pillsToHeatmap(pills);
     let scale = datavzrdScale(heatmap);
 
     if (value !== "") {
         let values = value.split(pills.pills.separator).map(item => item.trim());
         let content = values.map( v => {
             let color = scale(v);
-            return `<span style="padding: 4px 8px; margin: 2px; border-radius: 12px; background-color: ${color};">${v}</span>`;
+            return renderPill(v, color, pills.pills.ellipsis);
         }).join("");
         $(`${div}`)[0].innerHTML = content;
     }
+    $('[data-toggle="tooltip"]').tooltip({ sanitizeFn: function (content) { return content; } })
 }
 
 function datavzrdScale(heatmap) {

--- a/web/src/datavzrd.js
+++ b/web/src/datavzrd.js
@@ -191,9 +191,9 @@ function colorizeColumn(ah, columns, heatmap, detail_mode, header_label_length) 
     var table_rows = $("#table").bootstrapTable('getData', {useCurrentPage: "true"});
     var custom_func = heatmap.heatmap["custom-content"];
 
-    
+
     let scale = datavzrdScale(heatmap);
-    
+
 
     $(`table > tbody > tr td:nth-child(${index})`).each(
         function() {
@@ -209,6 +209,19 @@ function colorizeColumn(ah, columns, heatmap, detail_mode, header_label_length) 
             row++;
         }
     );
+}
+
+function renderPill(value, color, ellipsis) {
+  if (ellipsis === 0) {
+    return `<span style="margin: 2px; padding:6px 12px; border-radius: 12px; height:24px; width: 24px; background-color: ${color};" data-toggle="tooltip" data-trigger="hover click focus" title='${value}'></span>`;
+  } else {
+    const styles = `padding: 4px 8px; margin: 2px; border-radius: 12px; background-color: ${color};`;
+    if (ellipsis === undefined || value.length <= ellipsis) {
+      return `<span style="${styles}">${value}</span>`;
+    } else {
+      return `<span style="${styles}" data-toggle="tooltip" data-trigger="hover click focus" title='${value}'>${value.substring(0, ellipsis)}...</span>`;
+    }
+  }
 }
 
 function renderPills(ah, columns, pills, detail_mode, header_label_length) {
@@ -234,7 +247,7 @@ function renderPills(ah, columns, pills, detail_mode, header_label_length) {
                 let values = value.split(pills.pills.separator).map(item => item.trim());
                 let content = values.map( v => {
                     let color = scale(v);
-                    return `<span style="padding: 4px 8px; margin: 2px; border-radius: 12px; background-color: ${color};">${v}</span>`;
+                    return renderPill(v, color, pills.pills.ellipsis);
                 }).join("");
                 this.innerHTML = `<div style="display: inline-block">${content}</div>`;
             }


### PR DESCRIPTION
The logic for `renderPill` is similar to the existing logic in `shortenColumn`. However, the pills require different wrapping elements, so it was easier to duplicate some of this logic than to try and unify these utilities.

The new logic also supports pills with `ellipsis === 0`, in which case the pills are rendered as circles without any text content, and the pill value is shown in a tooltip on hover.

fixes #880 