### PR TITLE
fix: Replace dom-to-svg with html-to-image for SVG downloads

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -22,7 +22,7 @@
     "vega-embed": "^6.22.1",
     "vega-lite": "^5.9.3",
     "d3": "^7.8.5",
-    "dom-to-svg": "0.12.2"
+    "html-to-image": "1.11.13"
   },
   "devDependencies": {
     "@rspack/core": "^0.7.5",


### PR DESCRIPTION
This pull request includes several changes to the `web` package to replace the `dom-to-svg` library with `html-to-image` and improve the handling of SVG downloads. Additionally, it includes minor improvements to HTML attributes. The most important changes are as follows:

### Library Replacement:
* [`web/package.json`](diffhunk://#diff-b861012a5dd72b8a9f3281b7cf09f5a779c98569d040b1bbc1db50f1b15e7cceL25-R25): Replaced the `dom-to-svg` library with `html-to-image` for better SVG handling.
* [`web/src/datavzrd.js`](diffhunk://#diff-ff7315eccecc4e262837c3fcc7c3e46882ee07f19502b96aa6010a63b74d3ff2L13-R13): Updated import statement to use `html-to-image` instead of `dom-to-svg`.

### SVG Download Improvements:
* [`web/src/datavzrd.js`](diffhunk://#diff-ff7315eccecc4e262837c3fcc7c3e46882ee07f19502b96aa6010a63b74d3ff2L1439-R1440): Removed `addRotationTransform` function and updated `downloadSVG` to handle data URLs directly. [[1]](diffhunk://#diff-ff7315eccecc4e262837c3fcc7c3e46882ee07f19502b96aa6010a63b74d3ff2L1439-R1440) [[2]](diffhunk://#diff-ff7315eccecc4e262837c3fcc7c3e46882ee07f19502b96aa6010a63b74d3ff2R1449-L1484)
* [`web/src/datavzrd.js`](diffhunk://#diff-ff7315eccecc4e262837c3fcc7c3e46882ee07f19502b96aa6010a63b74d3ff2L1506-L1517): Updated `screenshot_table` function to use `html-to-image` for SVG generation and added a filter function to exclude certain nodes. [[1]](diffhunk://#diff-ff7315eccecc4e262837c3fcc7c3e46882ee07f19502b96aa6010a63b74d3ff2L1506-L1517) [[2]](diffhunk://#diff-ff7315eccecc4e262837c3fcc7c3e46882ee07f19502b96aa6010a63b74d3ff2R1499-R1501)

### HTML Attribute Consistency:
* [`web/src/datavzrd.js`](diffhunk://#diff-ff7315eccecc4e262837c3fcc7c3e46882ee07f19502b96aa6010a63b74d3ff2L372-R374): Standardized the use of double quotes for HTML attributes in the `linkUrlColumn` function. [[1]](diffhunk://#diff-ff7315eccecc4e262837c3fcc7c3e46882ee07f19502b96aa6010a63b74d3ff2L372-R374) [[2]](diffhunk://#diff-ff7315eccecc4e262837c3fcc7c3e46882ee07f19502b96aa6010a63b74d3ff2L384-R386)