### PR TITLE
fix: Update popover event handling and increase z-index for better visibility

### DIFF
--- a/web/src/datavzrd.js
+++ b/web/src/datavzrd.js
@@ -1125,7 +1125,7 @@ export function load() {
                                 data_content = data_content.concat(checkbox);
                             }
                             $(`table > thead > tr th:nth-child(${index}) > div.th-inner`).append(`<div class="sym ic" id="filter-${index}-container" data-column-title='${title.replace(/'/g, "&#39;")}' data-toggle="popover" data-placement="top" data-trigger="click focus" data-html="true" data-content="${data_content}"> ${search_icon}</div>`);
-                            $(`#filter-${index}-container`).on('click', function (e) {
+                            $(`#filter-${index}-container`).on('shown.bs.popover', function (e) {
                                 $('input:checkbox').change(function (event) {
                                     if (!event.currentTarget.checked) {
                                         checkbox_filters[title].push(event.currentTarget.id);
@@ -1152,7 +1152,7 @@ export function load() {
                         if(!reset) {
                             let search_icon = '<svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-search" fill="currentColor" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M10.442 10.442a1 1 0 0 1 1.415 0l3.85 3.85a1 1 0 0 1-1.414 1.415l-3.85-3.85a1 1 0 0 1 0-1.415z"/><path fill-rule="evenodd" d="M6.5 12a5.5 5.5 0 1 0 0-11 5.5 5.5 0 0 0 0 11zM13 6.5a6.5 6.5 0 1 1-13 0 6.5 6.5 0 0 1 13 0z"/></svg>';
                             $(`table > thead > tr th:nth-child(${index}) > div.th-inner`).append(`<div class="sym ic" id="filter-${index}-container" data-column-title='${title.replace(/'/g, "&#39;")}' data-toggle="popover" data-placement="top" data-trigger="click focus" data-html="true" data-content="<input class='form-control form-control-sm' id='filter-${index}' data-title='${title.replace(/'/g, "&#39;")}' placeholder='Filter...'>"> ${search_icon}</div>`);
-                            $(`#filter-${index}-container`).on('click', function (e) {
+                            $(`#filter-${index}-container`).on('shown.bs.popover', function (e) {
                                 $(`#filter-${index}`).on('input', function(event) {
                                     filters[event.target.dataset.title] = $(`#filter-${index}`).val();
                                     $('#table').bootstrapTable('filterBy', {"":""}, {

--- a/web/style/datavzrd.css
+++ b/web/style/datavzrd.css
@@ -357,7 +357,7 @@ footer {
 }
 
 .popover {
-    z-index: 2 !important;
+    z-index: 9999 !important;
 }
 
 .datavzrd-img {


### PR DESCRIPTION
This pull request includes changes to the `web/src/datavzrd.js` and `web/style/datavzrd.css` files to improve the behavior and appearance of popovers in the application. The most important changes include updating the event listener for popover activation and adjusting the z-index of popovers to ensure they appear above other elements.

Popover behavior improvements:

* [`web/src/datavzrd.js`](diffhunk://#diff-ff7315eccecc4e262837c3fcc7c3e46882ee07f19502b96aa6010a63b74d3ff2L1128-R1128): Changed the event listener from `'click'` to `'shown.bs.popover'` for the popover activation to ensure proper handling of checkbox filters within the popover.
* [`web/src/datavzrd.js`](diffhunk://#diff-ff7315eccecc4e262837c3fcc7c3e46882ee07f19502b96aa6010a63b74d3ff2L1155-R1155): Updated the event listener from `'click'` to `'shown.bs.popover'` for the popover activation to handle input filtering correctly within the popover.

CSS adjustments:

* [`web/style/datavzrd.css`](diffhunk://#diff-5632f00051868d6b7b33740bf585dfd56933d64c10c256ce790fef7cbc8205edL360-R360): Increased the `z-index` of the `.popover` class to `9999` to ensure popovers are displayed above other elements.