### PR TITLE
feat: Add support for merged pill rendering

### DIFF
--- a/src/spec.rs
+++ b/src/spec.rs
@@ -1016,6 +1016,8 @@ pub struct PillsSpec {
     #[serde(default)]
     pub ellipsis: Option<u32>,
     #[serde(default)]
+    pub merge: bool,
+    #[serde(default)]
     pub aux_domain_columns: AuxDomainColumns,
 }
 

--- a/web/src/datavzrd.js
+++ b/web/src/datavzrd.js
@@ -228,16 +228,24 @@ function colorizeColumn(ah, columns, heatmap, detail_mode, header_label_length, 
     );
 }
 
-function renderPill(value, color, ellipsis) {
-    if (ellipsis === 0) {
-        return `<span style="margin: 2px; padding:6px 12px; border-radius: 12px; height:24px; width: 24px; background-color: ${color};" data-toggle="tooltip" data-trigger="hover click focus" title='${value}'></span>`;
+function renderPill(value, color, ellipsis, merge = false, position = "middle") {
+    let styles = `padding: 4px 8px; background-color: ${color};`;
+    if (!merge) {
+        styles += "margin: 2px; border-radius: 12px;";
     } else {
-        const styles = `padding: 4px 8px; margin: 2px; border-radius: 12px; background-color: ${color};`;
-        if (ellipsis === undefined || value.length <= ellipsis) {
-            return `<span style="${styles}">${value}</span>`;
-        } else {
-            return `<span style="${styles}" data-toggle="tooltip" data-trigger="hover click focus" title='${value}'>${value.substring(0, ellipsis)}...</span>`;
-        }
+        let radius = position === "first" ? "12px 0 0 12px"
+                  : position === "last" ? "0 12px 12px 0"
+                  : position === "only" ? "12px"
+                  : "0";
+        styles += `border-radius: ${radius}; margin: 0;`;
+    }
+
+    if (ellipsis === 0) {
+        return `<span style="${styles}; padding:6px 12px; height:24px; width:24px;" data-toggle="tooltip" data-trigger="hover click focus" title='${value}'></span>`;
+    } else if (ellipsis === undefined || value.length <= ellipsis) {
+        return `<span style="${styles}">${value}</span>`;
+    } else {
+        return `<span style="${styles}" data-toggle="tooltip" data-trigger="hover click focus" title='${value}'>${value.substring(0, ellipsis)}...</span>`;
     }
 }
 
@@ -266,9 +274,13 @@ function renderPills(ah, columns, pills, detail_mode, header_label_length, colum
             var value = table_rows[row][pills.title];
             if (value !== "") {
                 let values = value.split(pills.pills.separator).map(item => item.trim());
-                let content = values.map( v => {
+                let content = values.map((v, i) => {
+                    let pos = values.length === 1 ? "only"
+                             : i === 0 ? "first"
+                             : i === values.length - 1 ? "last"
+                             : "middle";
                     let color = scale(v);
-                    return renderPill(v, color, pills.pills.ellipsis);
+                    return renderPill(v, color, pills.pills.ellipsis, pills.pills.merge, pos);
                 }).join("");
                 this.innerHTML = `<div style="display: inline-block; margin: 8px 0;">${content}</div>`;
             }
@@ -283,9 +295,13 @@ function renderDetailPills(value, div, pills) {
 
     if (value !== "") {
         let values = value.split(pills.pills.separator).map(item => item.trim());
-        let content = values.map( v => {
+        let content = values.map((v, i) => {
+            let pos = values.length === 1 ? "only"
+                     : i === 0 ? "first"
+                     : i === values.length - 1 ? "last"
+                     : "middle";
             let color = scale(v);
-            return renderPill(v, color, pills.pills.ellipsis);
+            return renderPill(v, color, pills.pills.ellipsis, pills.pills.merge, pos);
         }).join("");
         $(`${div}`)[0].innerHTML = content;
     }


### PR DESCRIPTION
This PR introduces a new keyword `merge` to `pills` that allows to ommit the padding between pills and merge them into one. This should save some space when many values are present in a single cell. Example usage:

```yaml
Genre:
  plot:
    pills:
      color-scheme: category20
      ellipsis: 0
      merge: true
```

resulting in:

<img width="324" alt="Bildschirmfoto 2025-04-25 um 18 33 02" src="https://github.com/user-attachments/assets/7c168c47-1363-4d96-bcfa-ba8dbf222e5c" />
