### PR TITLE
fix: Add column name to float warning message

### DIFF
--- a/src/utils/column_type.rs
+++ b/src/utils/column_type.rs
@@ -15,7 +15,7 @@ pub enum ColumnType {
 }
 
 impl ColumnType {
-    fn update(&mut self, value: &str, warn: bool) -> Result<bool> {
+    fn update(&mut self, value: &str, column: &str, warn: bool) -> Result<bool> {
         let mut float_warning = warn;
         if !value.is_na() {
             *self = match (
@@ -32,7 +32,7 @@ impl ColumnType {
                 (false, false, _) | (_, _, ColumnType::String) => {
                     let replaced_comma = value.replace(",", ".");
                     if f64::from_str(&replaced_comma).is_ok() && value.contains(",") && !warn {
-                        warn!("The value '{value}' and potentially more values of the same column contain a comma and may be a float and will not be parsed as a one. Consider using '.' for decimal points.");
+                        warn!("The value '{value}' and potentially more values of the column {column} contain a comma and may be a float and will not be parsed as a one. Consider using '.' for decimal points.");
                         float_warning = true;
                     }
                     ColumnType::String
@@ -64,7 +64,7 @@ pub fn classify_table(dataset: &DatasetSpecs, warn: bool) -> Result<HashMap<Stri
             let column_type = classification.get_mut(title).unwrap();
             warnings.insert(
                 title.to_string(),
-                column_type.update(value, *warnings.get(title).unwrap())?,
+                column_type.update(value, title, *warnings.get(title).unwrap())?,
             );
         }
     }


### PR DESCRIPTION
This pull request updates the `ColumnType` utility in `src/utils/column_type.rs` to improve the clarity of warning messages by including the column name in the output. The changes primarily affect the `update` method and its usage across the codebase.

### Updates to `ColumnType` warnings:

* [`src/utils/column_type.rs`](diffhunk://#diff-ec53979c9d86ff52a38afa89678074aebf9b0cad8b15ff078b41c8c2d5c057a0L18-R18): Modified the `update` method in `ColumnType` to accept an additional `column` parameter, allowing warning messages to specify the column name.
* [`src/utils/column_type.rs`](diffhunk://#diff-ec53979c9d86ff52a38afa89678074aebf9b0cad8b15ff078b41c8c2d5c057a0L35-R35): Updated the warning message in the `update` method to include the column name, enhancing the context for users encountering float-related parsing issues.

### Code adjustments to support the new `update` method signature:

* [`src/utils/column_type.rs`](diffhunk://#diff-ec53979c9d86ff52a38afa89678074aebf9b0cad8b15ff078b41c8c2d5c057a0L67-R67): Adjusted the `classify_table` function to pass the column name to the `update` method, ensuring compatibility with the updated signature.