### PR TITLE
fix: Update readervzrd

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ serde = { version = "1", features = ["derive"] }
 clap = { version = "4.5.41", features = ["color", "suggestions", "derive", "env"] }
 anyhow = "1"
 thiserror = "2"
-readervzrd = "0.2.0"
+readervzrd = "0.2.1"
 typed-builder = "0.21"
 serde_yaml = "0.8" # https://github.com/AlexanderThaller/format_serde_error/pull/23
 serde_with = { version = "3.14.0", features = ["macros"] }


### PR DESCRIPTION
This pull request includes a minor update to the `Cargo.toml` file. The version of the `readervzrd` dependency has been incremented from `0.2.0` to `0.2.1`.