### PR TITLE
ci: Use pnpm setup action

### DIFF
--- a/.github/workflows/apply-clippy-lints.yaml
+++ b/.github/workflows/apply-clippy-lints.yaml
@@ -13,7 +13,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Install yte
         run: pip install yte
-      - name: Install pnpm
-        run: npm install -g pnpm
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
       - name: Auto apply clippy lints
         uses: fxwiegand/apply-clippy-lints@v1.0.4

--- a/.github/workflows/example-report-on-pr.yml
+++ b/.github/workflows/example-report-on-pr.yml
@@ -1,7 +1,7 @@
 name: Generate example report for downloading
 on:
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   generate_example_report:
@@ -20,8 +20,9 @@ jobs:
       - name: Install yte
         run: pip install yte
 
-      - name: Install pnpm
-        run: npm install -g pnpm
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
 
       - name: Generate report
         run: cargo run .examples/example-config.yaml --output example-report

--- a/.github/workflows/example-report.yml
+++ b/.github/workflows/example-report.yml
@@ -1,7 +1,7 @@
 name: Deploy example report to GitHub Pages
 on:
   push:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   generate_example_report:
@@ -20,8 +20,9 @@ jobs:
       - name: Install yte
         run: pip install yte
 
-      - name: Install pnpm
-        run: npm install -g pnpm
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
 
       - name: Generate report
         run: cargo run .examples/example-config.yaml --output example-report

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,7 +13,6 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
-
       - uses: GoogleCloudPlatform/release-please-action@v4
         id: release
         with:
@@ -36,8 +35,9 @@ jobs:
           toolchain: stable
           override: true
 
-      - name: Install pnpm
-        run: npm install -g pnpm
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
 
       - name: Install system dependencies
         run: |
@@ -52,54 +52,55 @@ jobs:
           args: --token ${{ secrets.CRATES_IO_TOKEN }}
 
   update-webview:
-      runs-on: ubuntu-latest
-      needs:
-        - release-please
-        - publish
-      if: ${{ needs.release-please.outputs.release_created }}
-      steps:
-        - name: Checkout repository
-          uses: actions/checkout@v3
-          with:
-            path: datavzrd
+    runs-on: ubuntu-latest
+    needs:
+      - release-please
+      - publish
+    if: ${{ needs.release-please.outputs.release_created }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          path: datavzrd
 
-        - name: Install yte
-          run: pip install yte
+      - name: Install yte
+        run: pip install yte
 
-        - name: Checkout view repo
-          uses: actions/checkout@v3
-          with:
-            repository: datavzrd/view
-            path: view
+      - name: Checkout view repo
+        uses: actions/checkout@v3
+        with:
+          repository: datavzrd/view
+          path: view
 
-        - name: Install stable toolchain
-          uses: actions-rs/toolchain@v1
-          with:
-            toolchain: stable
-            override: true
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
 
-        - name: Install pnpm
-          run: npm install -g pnpm
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
 
-        - name: Build
-          run: |
-            cd datavzrd
-            cargo build --release
+      - name: Build
+        run: |
+          cd datavzrd
+          cargo build --release
 
-        - name: Copy bundle.js
-          run: |
-            outdir=view/static/${{ needs.release-please.outputs.tag_name }}
-            mkdir -p $outdir
-            cp datavzrd/target/release/build/datavzrd-*/out/web/dist/bundle.js $outdir/bundle.js
+      - name: Copy bundle.js
+        run: |
+          outdir=view/static/${{ needs.release-please.outputs.tag_name }}
+          mkdir -p $outdir
+          cp datavzrd/target/release/build/datavzrd-*/out/web/dist/bundle.js $outdir/bundle.js
 
-        - name: Commit and push changes
-          uses: cpina/github-action-push-to-another-repository@main
-          env:
-            SSH_DEPLOY_KEY: ${{ secrets.SSH_DEPLOY_KEY }}
-          with:
-            source-directory: view/static/${{ needs.release-please.outputs.tag_name }}
-            destination-github-username: 'datavzrd'
-            destination-repository-name: 'view'
-            target-branch: main
-            commit-message: Add datavzrd ${{ needs.release-please.outputs.tag_name }} bundle.js
-            target-directory: static/${{ needs.release-please.outputs.tag_name }}/
+      - name: Commit and push changes
+        uses: cpina/github-action-push-to-another-repository@main
+        env:
+          SSH_DEPLOY_KEY: ${{ secrets.SSH_DEPLOY_KEY }}
+        with:
+          source-directory: view/static/${{ needs.release-please.outputs.tag_name }}
+          destination-github-username: "datavzrd"
+          destination-repository-name: "view"
+          target-branch: main
+          commit-message: Add datavzrd ${{ needs.release-please.outputs.tag_name }} bundle.js
+          target-directory: static/${{ needs.release-please.outputs.tag_name }}/

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   Formatting:
@@ -19,33 +19,34 @@ jobs:
           toolchain: stable
           override: true
           components: rustfmt
-      
+
       - name: Check format
         run: cargo fmt -- --check
 
   Linting:
-     runs-on: ubuntu-latest
-     steps:
-       - name: Checkout repository
-         uses: actions/checkout@v2
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
 
-       - name: Install stable toolchain
-         uses: actions-rs/toolchain@v1
-         with:
-           toolchain: stable
-           override: true
-           components: clippy
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          components: clippy
 
-       - name: Install yte
-         run: pip install yte
+      - name: Install yte
+        run: pip install yte
 
-       - name: Install pnpm
-         run: npm install -g pnpm
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
 
-       - name: Lint with clippy
-         uses: actions-rs/clippy-check@v1
-         with:
-           token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Lint with clippy
+        uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
   Testing:
     needs: Formatting
@@ -63,8 +64,9 @@ jobs:
       - name: Install yte
         run: pip install yte
 
-      - name: Install pnpm
-        run: npm install -g pnpm
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
 
       - name: Install GitHub CLI
         run: |
@@ -73,10 +75,9 @@ jobs:
 
       - name: Authenticate with GitHub
         run: gh auth login --with-token <<< "${{ secrets.GITHUB_TOKEN }}"
-      
+
       - uses: Swatinem/rust-cache@v1.3.0
 
       - uses: actions-rs/cargo@v1
         with:
           command: test
-


### PR DESCRIPTION
This pull request updates the way `pnpm` is installed across several GitHub Actions workflow files to use the official `pnpm/action-setup` action, specifying version 10, instead of installing it globally via `npm install -g pnpm`. 