### PR TITLE
ci: Update apply-clippy-lints action to version 1.0.5

### DIFF
--- a/.github/workflows/apply-clippy-lints.yaml
+++ b/.github/workflows/apply-clippy-lints.yaml
@@ -17,4 +17,4 @@ jobs:
         with:
           version: 10
       - name: Auto apply clippy lints
-        uses: fxwiegand/apply-clippy-lints@v1.0.4
+        uses: fxwiegand/apply-clippy-lints@v1.0.5


### PR DESCRIPTION
This pull request updates the version of the Clippy lints GitHub Action to ensure the latest improvements and fixes are applied.

* DevOps: Updated the `fxwiegand/apply-clippy-lints` action from version `v1.0.4` to `v1.0.5` in `.github/workflows/apply-clippy-lints.yaml`.