### PR TITLE
fix: Validate plot datasets exist in ItemsSpec

### DIFF
--- a/src/spec.rs
+++ b/src/spec.rs
@@ -295,6 +295,17 @@ impl ItemsSpec {
                     }
                 }
             }
+            if view.render_plot.is_some() {
+                if let Some(datasets) = &view.datasets {
+                    for dataset in datasets.values() {
+                        if !self.datasets.contains_key(dataset) {
+                            bail!(ConfigError::MissingDataset {
+                                dataset: dataset.to_string()
+                            })
+                        }
+                    }
+                }
+            }
         }
         for (name, dataset) in &self.datasets {
             if let Some(linkouts) = &dataset.links {


### PR DESCRIPTION
This pull request adds a validation step to ensure that all datasets referenced in a plot view are present in the configuration. This helps prevent runtime errors due to missing datasets when rendering plots. Fixes #1077.