### PR TITLE
fix: Fix arbitrary additional header order

### DIFF
--- a/web/src/datavzrd.js
+++ b/web/src/datavzrd.js
@@ -579,7 +579,7 @@ export function load() {
 
     let additional_headers = "";
 
-    for (const ah of header_config.headers) {
+    for (const ah of [...header_config.headers].sort((a, b) => a.row - b.row)) {
       additional_headers += "<tr>";
       if (config.detail_mode || ah.label) {
         additional_headers += "<td";


### PR DESCRIPTION
This PR orders header rows to ensure that additional headers are rendered in a consistent order which would have caused issues before.