### PR TITLE
fix: Sanitize heatmap legend gradient ids properly

### DIFF
--- a/web/src/description.js
+++ b/web/src/description.js
@@ -132,7 +132,7 @@ function renderHeatmapLegends(heatmaps) {
       const gradientHTML = generateSVGGradientLegend(
         scale,
         domain,
-        `grad-${legendTitle.replace(/\s+/g, "-")}`,
+        `grad-${legendTitle.replace(/[^a-zA-Z0-9_-]+/g, "-")}`,
       );
       legends[legendTitle] = `
                 <div style="display:flex;align-items:center;gap:10px;margin:5px 0;">


### PR DESCRIPTION
This PR replaces all special characters when building the SVG gradient id from a legend title, so titles containing parentheses, colons, etc. no longer produce a broken gradient.