### PR TITLE
fix: Hide header sort and column drag controls in SVG screenshot

### DIFF
--- a/web/src/datavzrd.js
+++ b/web/src/datavzrd.js
@@ -1476,7 +1476,8 @@ function downloadSVG(dataUrl, fileName) {
 }
 
 function filter(node) {
-  return !(node.classList && node.classList.contains("sym"));
+  const hidden = ["sym", "header-sort", "col-drag-handle"];
+  return !hidden.some((c) => node.classList?.contains(c));
 }
 
 export function screenshot_table() {


### PR DESCRIPTION
Prevents the drag handle and column sort icons from occurring in the exported SVG.