### PR TITLE
feat: Add narrow column view option

### DIFF
--- a/src/render/portable/mod.rs
+++ b/src/render/portable/mod.rs
@@ -263,6 +263,7 @@ impl Renderer for ItemRenderer {
                         additional_headers,
                         &table.render_table.as_ref().unwrap().headers,
                         is_single_page,
+                        table.narrow,
                         table.single_page_page_size,
                         pages,
                         webview_host,
@@ -420,6 +421,7 @@ fn render_table_javascript<P: AsRef<Path>>(
     additional_headers: Option<Vec<Vec<String>>>,
     header_specs: &Option<HashMap<u32, HeaderSpecs>>,
     is_single_page: bool,
+    narrow: bool,
     page_size: usize,
     pages: usize,
     webview_host: &str,
@@ -446,6 +448,7 @@ fn render_table_javascript<P: AsRef<Path>>(
         render_columns,
         additional_columns,
         is_single_page,
+        narrow,
         page_size,
         titles,
         webview_host,
@@ -677,6 +680,7 @@ struct CustomPlotConfig {
 #[derive(Serialize, Debug, Clone, PartialEq)]
 struct JavascriptConfig {
     detail_mode: bool,
+    narrow: bool,
     webview_controls: bool,
     webview_host: String,
     is_single_page: bool,
@@ -726,6 +730,7 @@ impl JavascriptConfig {
         config: &HashMap<String, RenderColumnSpec>,
         additional_columns: &Option<HashMap<String, AdditionalColumnSpec>>,
         is_single_page: bool,
+        narrow: bool,
         page_size: usize,
         columns: &[String],
         webview_host: &str,
@@ -783,6 +788,7 @@ impl JavascriptConfig {
                 > 0;
         Self {
             detail_mode,
+            narrow,
             webview_controls,
             webview_host: webview_host.to_string(),
             is_single_page,

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -500,6 +500,8 @@ impl DatasetSpecs {
 pub struct ItemSpecs {
     #[serde(default)]
     pub hidden: bool,
+    #[serde(default)]
+    pub narrow: bool,
     pub dataset: Option<String>,
     pub datasets: Option<HashMap<String, String>>,
     #[serde(default = "default_page_size")]
@@ -526,6 +528,7 @@ impl ItemSpecs {
     fn merge_item_specs(&self, other: &ItemSpecs) -> Result<ItemSpecs> {
         let mut merged = self.clone();
         merged.hidden = other.hidden;
+        merged.narrow = other.narrow;
         if let Some(dataset) = &other.dataset {
             merged.dataset = Some(dataset.to_string());
         }
@@ -1650,6 +1653,7 @@ mod tests {
 
         let expected_table_spec = ItemSpecs {
             hidden: false,
+            narrow: false,
             dataset: Some("table-a".to_string()),
             datasets: None,
             page_size: 100,
@@ -1727,6 +1731,7 @@ mod tests {
 
         let expected_item_spec = ItemSpecs {
             hidden: false,
+            narrow: false,
             dataset: Some("table-a".to_string()),
             datasets: None,
             page_size: default_page_size(),
@@ -1788,6 +1793,7 @@ mod tests {
 
         let expected_item_spec = ItemSpecs {
             hidden: false,
+            narrow: false,
             dataset: Some("table-a".to_string()),
             datasets: None,
             page_size: default_page_size(),
@@ -1833,6 +1839,7 @@ mod tests {
     fn test_additional_header_config_deserialization() {
         let expected_item_spec = ItemSpecs {
             hidden: false,
+            narrow: false,
             dataset: Some("table-a".to_string()),
             datasets: None,
             page_size: default_page_size(),
@@ -2274,6 +2281,7 @@ mod tests {
         };
         let expected_item_specs = ItemSpecs {
             hidden: false,
+            narrow: false,
             dataset: Some("table-a".to_string()),
             datasets: None,
             page_size: 184_usize,

--- a/src/suggest.rs
+++ b/src/suggest.rs
@@ -90,6 +90,7 @@ pub(crate) fn suggest(files: Vec<PathBuf>, separator: Vec<char>, name: String) -
         };
         let item_spec = ItemSpecs {
             hidden: false,
+            narrow: false,
             dataset: Some(dataset_name.to_string()),
             datasets: None,
             page_size: default_page_size(),

--- a/web/src/datavzrd.js
+++ b/web/src/datavzrd.js
@@ -380,10 +380,6 @@ function render(
   }
 }
 
-// Collapses every column that is neither pinned nor backed by a plot into a thin
-// strip, hiding its header label and controls. The strip keeps a tooltip with the
-// column name so it stays identifiable. Reapplied on every render so the state
-// survives bootstrap-table rebuilds.
 function applyNarrowView(columnIndexMap) {
   const readable = new Set([
     ...config.pinned_columns,
@@ -1559,7 +1555,7 @@ export function screenshot_table() {
     .querySelectorAll(".linkout-raw-value")
     .forEach((el) => (el.style.display = "table-cell"));
   const table_element = document.getElementById("table");
-  // Narrow columns hide their values on screen via font-size: 0, which html-to-image does not honor.
+  // Narrow columns hide their values on screen via font-size: 0, which html-to-image does not respect.
   // Remove for scrrenshot then restore it.
   const narrow_contents = [];
   document.querySelectorAll("td.narrow-col").forEach((cell) => {

--- a/web/src/datavzrd.js
+++ b/web/src/datavzrd.js
@@ -50,6 +50,7 @@ import "../style/bootstrap-table-fixed-columns.min.css";
 import "../style/datavzrd.css";
 
 let LINE_NUMBERS = false;
+let NARROW_VIEW = false;
 
 export function downloadCSV() {
   var data = $("#table").bootstrapTable("getData");
@@ -370,9 +371,48 @@ function render(
 
   hideLabelColumn();
 
+  applyNarrowView(columnIndexMap);
+
   if (config["to_be_hidden"]) {
     for (const hc of config["to_be_hidden"]) {
       hide(columnIdMap[hc], true, columnIndexMap);
+    }
+  }
+}
+
+// Collapses every column that is neither pinned nor backed by a plot into a thin
+// strip, hiding its header label and controls. The strip keeps a tooltip with the
+// column name so it stays identifiable. Reapplied on every render so the state
+// survives bootstrap-table rebuilds.
+function applyNarrowView(columnIndexMap) {
+  const readable = new Set([
+    ...config.pinned_columns,
+    ...config.tick_titles,
+    ...config.bar_titles,
+    ...config.bubble_titles,
+    ...config.custom_plot_titles,
+  ]);
+  for (const column of config.displayed_columns) {
+    if (readable.has(column)) continue;
+    const index = columnIndexMap[column];
+    const cells = $(
+      `table > thead > tr > :nth-child(${index}), table > tbody > tr > td:nth-child(${index})`,
+    );
+    const header = $(`table > thead > tr:first-child > :nth-child(${index})`);
+    if (NARROW_VIEW) {
+      cells.addClass("narrow-col");
+      if (!header.data("bs.tooltip")) {
+        header.attr("title", column).tooltip({
+          placement: "bottom",
+          trigger: "hover",
+          sanitizeFn: (content) => content,
+        });
+      }
+    } else {
+      cells.removeClass("narrow-col");
+      if (header.data("bs.tooltip")) {
+        header.tooltip("dispose");
+      }
     }
   }
 }
@@ -391,6 +431,7 @@ export function load() {
     document.title = "datavzrd report";
     const columnIndexMap = buildColumnIndexMap();
     window.columnIndexMap = columnIndexMap;
+    NARROW_VIEW = config.narrow;
     config.original_displayed_columns = [...config.displayed_columns];
     render_html_contents();
     $(".table-container").show();
@@ -1220,6 +1261,10 @@ export function load() {
       });
     }
 
+    $("#toggleNarrowView").on("click", function () {
+      toggle_narrow_view();
+    });
+
     var rect = $(".fixed-table-container")[0].getBoundingClientRect();
     if (rect.left < 0 || rect.right > $(window).width()) {
       add_scroll_button();
@@ -1463,6 +1508,11 @@ export function toggle_line_numbers() {
   LINE_NUMBERS = !LINE_NUMBERS;
 }
 
+export function toggle_narrow_view() {
+  NARROW_VIEW = !NARROW_VIEW;
+  applyNarrowView(window.columnIndexMap);
+}
+
 function downloadSVG(dataUrl, fileName) {
   const blob = new Blob([decodeURIComponent(dataUrl.split(",")[1])], {
     type: "image/svg+xml",
@@ -1509,11 +1559,23 @@ export function screenshot_table() {
     .querySelectorAll(".linkout-raw-value")
     .forEach((el) => (el.style.display = "table-cell"));
   const table_element = document.getElementById("table");
+  // Narrow columns hide their values on screen via font-size: 0, which html-to-image does not honor.
+  // Remove for scrrenshot then restore it.
+  const narrow_contents = [];
+  document.querySelectorAll("td.narrow-col").forEach((cell) => {
+    narrow_contents.push([cell, cell.innerHTML]);
+    cell.innerHTML = "";
+  });
   htmlToImage
     .toSvg(table_element, { filter: filter })
     .then((dataUrl) =>
       downloadSVG(dataUrl, `${$("#view-selection").attr("title")}.svg`),
-    );
+    )
+    .finally(() => {
+      narrow_contents.forEach(([cell, html]) => {
+        cell.innerHTML = html;
+      });
+    });
   if (config.detail_mode) {
     document.querySelectorAll("table tr").forEach((row) => {
       const cells = row.querySelectorAll("td, th");

--- a/web/src/page.js
+++ b/web/src/page.js
@@ -79,6 +79,7 @@ export function render_html_contents() {
         }
         sidebar_html += '<li class="list-group-item sidebar-btn" id="resetColumnOrder-btn">Reset column order</li>';
         sidebar_html += '<li class="list-group-item sidebar-btn" id="toggleLineNumbers">Show/Hide Line Numbers</li>';
+        sidebar_html += '<li class="list-group-item sidebar-btn" id="toggleNarrowView">Toggle Narrow Columns</li>';
 
         // Group: Downloads
         if (config.has_excel_sheet) {

--- a/web/style/datavzrd.css
+++ b/web/style/datavzrd.css
@@ -145,6 +145,26 @@ th .th-inner {
     margin-bottom: 5px;
 }
 
+#table td.narrow-col,
+#table th.narrow-col {
+    max-width: 4px;
+    width: 4px;
+    overflow: hidden;
+    padding: 0 !important;
+}
+
+#table td.narrow-col {
+    font-size: 0 !important;
+}
+
+th.narrow-col .th-inner,
+th.narrow-col .sym,
+th.narrow-col .sym-container,
+th.narrow-col .header-sort,
+th.narrow-col .col-drag-handle {
+    display: none;
+}
+
 #vis-container {
     height: calc(100vh - 105px);
     padding-top: 50px;


### PR DESCRIPTION
This RP adds a "narrow view" that collapses all non-pinned columns into thin colored strips (hiding their header labels and controls, with the column name available as a tooltip) so very wide tables stay compact, toggleable at runtime via the top-right menu.