### PR TITLE
feat: Skip table data compression in debug mode

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -14,7 +14,7 @@ pub struct Datavzrd {
     #[arg(short, long, action = clap::ArgAction::Count)]
     pub(crate) _verbose: u8,
 
-    /// Activates debug mode. Javascript files are not minified.
+    /// Activates debug mode. Javascript files are not minified and table data is human readable.
     #[arg(long)]
     pub(crate) debug: bool,
 

--- a/src/render/portable/mod.rs
+++ b/src/render/portable/mod.rs
@@ -256,7 +256,13 @@ impl Renderer for ItemRenderer {
                         )?;
                     }
                     if !is_single_page {
-                        render_search_dialogs(&out_path, &headers, dataset, table.page_size, debug)?;
+                        render_search_dialogs(
+                            &out_path,
+                            &headers,
+                            dataset,
+                            table.page_size,
+                            debug,
+                        )?;
                     }
                     render_table_javascript(
                         &out_path,

--- a/src/render/portable/mod.rs
+++ b/src/render/portable/mod.rs
@@ -110,6 +110,7 @@ impl Renderer for ItemRenderer {
                             .collect(),
                         &self.specs.views,
                         &self.specs.default_view,
+                        debug,
                     )?;
                     continue;
                 }
@@ -154,6 +155,7 @@ impl Renderer for ItemRenderer {
                         &self.specs.report_name,
                         self.specs.needs_excel_sheet(),
                         &view_sizes,
+                        debug,
                     )?;
                 // Render HTML
                 } else if let Some(table_specs) = &table.render_html {
@@ -254,7 +256,7 @@ impl Renderer for ItemRenderer {
                         )?;
                     }
                     if !is_single_page {
-                        render_search_dialogs(&out_path, &headers, dataset, table.page_size)?;
+                        render_search_dialogs(&out_path, &headers, dataset, table.page_size, debug)?;
                     }
                     render_table_javascript(
                         &out_path,
@@ -360,15 +362,15 @@ fn render_page<P: AsRef<Path>>(
                 .unwrap()
             })
             .collect_vec();
-        Some(compress(json!(linkouts))?)
+        compress(json!(linkouts), debug)?
     } else {
-        None
+        Value::Null.to_string()
     };
 
-    let compressed_data = compress(json!(data))?;
+    let compressed_data = compress(json!(data), debug)?;
 
-    context.insert("data", &json!(compressed_data).to_string());
-    context.insert("linkouts", &json!(compressed_linkouts).to_string());
+    context.insert("data", &compressed_data);
+    context.insert("linkouts", &compressed_linkouts);
     context.insert("current_page", &page_index);
     context.insert("is_single_page", &is_single_page);
     context.insert(
@@ -1333,6 +1335,7 @@ fn render_search_dialogs<P: AsRef<Path>>(
     titles: &[String],
     dataset: &DatasetSpecs,
     page_size: usize,
+    debug: bool,
 ) -> Result<()> {
     let output_path = Path::new(path.as_ref()).join("search");
     fs::create_dir(&output_path)?;
@@ -1352,7 +1355,7 @@ fn render_search_dialogs<P: AsRef<Path>>(
                 .map(|(row, address)| (row, address.page + 1, address.row))
                 .collect_vec();
 
-            let compressed_data = compress(json!(records))?;
+            let compressed_data = compress(json!(records), debug)?;
 
             let mut templates = Tera::default();
             templates.add_raw_template(
@@ -1360,7 +1363,7 @@ fn render_search_dialogs<P: AsRef<Path>>(
                 include_str!("../../../templates/search_dialog.html.tera"),
             )?;
             let mut context = Context::new();
-            context.insert("data", &json!(compressed_data).to_string());
+            context.insert("data", &compressed_data);
             context.insert("records", &records);
             context.insert("title", &title);
 
@@ -1635,6 +1638,7 @@ fn render_plot_page<P: AsRef<Path>>(
     report_name: &String,
     has_excel_sheet: bool,
     view_sizes: &HashMap<String, String>,
+    debug: bool,
 ) -> Result<()> {
     let headers = dataset
         .reader()?
@@ -1691,9 +1695,9 @@ fn render_plot_page<P: AsRef<Path>>(
 
     let local: DateTime<Local> = Local::now();
 
-    let compressed_data = compress(json!(records))?;
+    let compressed_data = compress(json!(records), debug)?;
 
-    context.insert("data", &json!(compressed_data).to_string());
+    context.insert("data", &compressed_data);
     context.insert("description", &item_spec.description);
     context.insert("has_excel_sheet", &has_excel_sheet);
     context.insert(
@@ -1881,6 +1885,7 @@ fn render_plot_page_with_multiple_datasets<P: AsRef<Path>>(
     datasets: HashMap<String, &DatasetSpecs>,
     views: &HashMap<String, ItemSpecs>,
     default_view: &Option<String>,
+    debug: bool,
 ) -> Result<()> {
     let mut data = HashMap::new();
 
@@ -1915,9 +1920,9 @@ fn render_plot_page_with_multiple_datasets<P: AsRef<Path>>(
 
     let local: DateTime<Local> = Local::now();
 
-    let compressed_data = compress(json!(data))?;
+    let compressed_data = compress(json!(data), debug)?;
 
-    context.insert("datasets", &json!(compressed_data).to_string());
+    context.insert("datasets", &compressed_data);
     context.insert("description", &item_spec.description);
     context.insert(
         "tables",

--- a/src/utils/compress.rs
+++ b/src/utils/compress.rs
@@ -3,9 +3,12 @@ use jsonm::packer::{PackOptions, Packer};
 use lz_str::compress_to_utf16;
 use serde_json::{json, Value};
 
-pub(crate) fn compress(data: Value) -> Result<String> {
+pub(crate) fn compress(data: Value, debug: bool) -> Result<String> {
+    if debug {
+        return Ok(data.to_string());
+    }
     let mut packer = Packer::new();
     let options = PackOptions::new();
     let jsonm = packer.pack(&data, &options)?;
-    Ok(compress_to_utf16(&json!(jsonm).to_string()))
+    Ok(json!(compress_to_utf16(&json!(jsonm).to_string())).to_string())
 }

--- a/web/src/datavzrd.js
+++ b/web/src/datavzrd.js
@@ -1603,6 +1603,9 @@ export function screenshot_table() {
 }
 
 function decompress(data) {
+  if (typeof data !== "string") {
+    return data;
+  }
   var decompressed = JSON.parse(LZString.decompressFromUTF16(data));
   const unpacker = new jsonm.Unpacker();
   decompressed = unpacker.unpack(decompressed);


### PR DESCRIPTION
Should make debugging plots etc. much easier as this makes datavzrd skips LZString and JSONM compression. Thanks @tedil 