### PR TITLE
fix: Disable memoize_objects in rust-jsonm to prevent data corruption

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1627,8 +1627,9 @@ checksum = "a3c2a6c0b4b5637c41719973ef40c6a1cf564f9db6958350de6193fbee9c23f5"
 
 [[package]]
 name = "jsonm"
-version = "0.2.1"
-source = "git+https://github.com/andrewnester/rust-jsonm?branch=master#160862694f139df95763e1b72f3f0ceef524cf86"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b86792f3504fd604d10f67b87c0db3514df881542e22e4c46af9031dcce3262"
 dependencies = [
  "regex",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1628,8 +1628,7 @@ checksum = "a3c2a6c0b4b5637c41719973ef40c6a1cf564f9db6958350de6193fbee9c23f5"
 [[package]]
 name = "jsonm"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c05405079e700fdb5dbfdb6f7b0f121fb4cdc4e7ab026afaa377b5cc1b2bb8"
+source = "git+https://github.com/andrewnester/rust-jsonm?branch=master#160862694f139df95763e1b72f3f0ceef524cf86"
 dependencies = [
  "regex",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ minify-html = "0.18.1"
 simple_excel_writer = "0.2"
 slug = "0.1.6"
 md5 = "0.8.0"
-jsonm = "0.2.1"
+jsonm = { git = "https://github.com/andrewnester/rust-jsonm", branch = "master" }
 format_serde_error = "0.3.0"
 reqwest = { version = "0.13.4", features = ["blocking"] }
 pyo3 = { version = "0.29.0", features = ["auto-initialize", "abi3-py310"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ minify-html = "0.18.1"
 simple_excel_writer = "0.2"
 slug = "0.1.6"
 md5 = "0.8.0"
-jsonm = { git = "https://github.com/andrewnester/rust-jsonm", branch = "master" }
+jsonm = "0.2.2"
 format_serde_error = "0.3.0"
 reqwest = { version = "0.13.4", features = ["blocking"] }
 pyo3 = { version = "0.29.0", features = ["auto-initialize", "abi3-py310"] }

--- a/src/utils/compress.rs
+++ b/src/utils/compress.rs
@@ -8,7 +8,10 @@ pub(crate) fn compress(data: Value, debug: bool) -> Result<String> {
         return Ok(data.to_string());
     }
     let mut packer = Packer::new();
-    let options = PackOptions::new();
+    let options = PackOptions {
+        memoize_objects: false,
+        ..PackOptions::new()
+    };
     let jsonm = packer.pack(&data, &options)?;
     Ok(json!(compress_to_utf16(&json!(jsonm).to_string())).to_string())
 }


### PR DESCRIPTION
@tedil This should fix your plot that missed some data. Needs https://github.com/andrewnester/rust-jsonm/pull/17 to be released.