### PR TITLE
feat: Add --dryrun option

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -18,6 +18,10 @@ pub struct Datavzrd {
     #[arg(long)]
     pub(crate) debug: bool,
 
+    /// Do not execute anything. Only validate the configuration and report what would be rendered.
+    #[arg(short = 'n', long)]
+    pub(crate) dryrun: bool,
+
     /// Config file containing file paths and settings
     #[arg(value_name = "CONFIG", value_parser)]
     pub(crate) config: Option<PathBuf>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ pub mod utils;
 /// * `webview_url` - A string slice representing the base URL for webview links in the report.
 /// * `debug` - A boolean flag indicating whether to enable debug mode for rendering.
 /// * `overwrite_output` - A boolean flag indicating whether to overwrite the output directory if it is not empty.
+/// * `dryrun` - A boolean flag indicating whether to only validate the configuration and report what would be rendered, without writing anything.
 ///
 /// # Returns
 ///
@@ -37,9 +38,19 @@ pub fn render_report(
     webview_url: &str,
     debug: bool,
     overwrite_output: bool,
+    dryrun: bool,
 ) -> Result<()> {
     let config = ItemsSpec::from_file(config_file)?;
     config.validate()?;
+
+    if dryrun {
+        let count = config.views.len();
+        let views = if count == 1 { "view" } else { "views" };
+        println!(
+            "Configuration is valid. {count} {views} would be rendered to {output:?}. Nothing written as called with --dryrun/-n flag."
+        );
+        return Ok(());
+    }
 
     if !output.exists() {
         fs::create_dir(output)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,6 +57,7 @@ fn main() -> Result<()> {
                 &opt.webview_url,
                 opt.debug,
                 opt.overwrite_output,
+                opt.dryrun,
             )?;
         }
     }


### PR DESCRIPTION
This PR adds a `--dryrun` option that only checks and preprocesses the config while not actually rendering the output.