### PR TITLE
fix: Fix custom-content for link-to-url

### DIFF
--- a/src/render/portable/mod.rs
+++ b/src/render/portable/mod.rs
@@ -1148,6 +1148,7 @@ impl JavascriptHeatmapConfig {
 struct JavascriptLinkConfig {
     title: String,
     links: Vec<JavascriptLink>,
+    #[serde(rename = "custom-content")]
     custom_content: Option<String>,
 }
 


### PR DESCRIPTION
Wasn't working due a a serialization issue (js was expecting `custom-content` instead of `custom_content`).