### PR TITLE
fix: Skip serializing unset tick, bar and bubble plot fields

### DIFF
--- a/src/spec.rs
+++ b/src/spec.rs
@@ -2431,8 +2431,14 @@ mod tests {
             bubble_plot: None,
         };
         let yaml = serde_yaml::to_string(&plot).unwrap();
-        assert!(!yaml.contains("domain"), "unset domain should be omitted:\n{yaml}");
-        assert!(!yaml.contains("color"), "unset color should be omitted:\n{yaml}");
+        assert!(
+            !yaml.contains("domain"),
+            "unset domain should be omitted:\n{yaml}"
+        );
+        assert!(
+            !yaml.contains("color"),
+            "unset color should be omitted:\n{yaml}"
+        );
     }
 
     #[test]

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -1253,6 +1253,7 @@ impl PillsSpec {
     }
 }
 
+#[skip_serializing_none]
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct BubblePlot {
@@ -1275,6 +1276,7 @@ impl BubblePlot {
     }
 }
 
+#[skip_serializing_none]
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct TickPlot {
@@ -1525,6 +1527,7 @@ impl SequentialScheme {
     }
 }
 
+#[skip_serializing_none]
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct BarPlot {
@@ -2411,6 +2414,25 @@ mod tests {
             oscar_config.get("birth_y").unwrap().to_owned(),
             expected_render_column_spec
         );
+    }
+
+    #[test]
+    fn unset_tick_plot_fields_are_omitted() {
+        let plot = PlotSpec {
+            tick_plot: Some(TickPlot {
+                scale_type: ScaleType::Linear,
+                domain: None,
+                aux_domain_columns: AuxDomainColumns(None),
+                color: None,
+            }),
+            heatmap: None,
+            bar_plot: None,
+            pills: None,
+            bubble_plot: None,
+        };
+        let yaml = serde_yaml::to_string(&plot).unwrap();
+        assert!(!yaml.contains("domain"), "unset domain should be omitted:\n{yaml}");
+        assert!(!yaml.contains("color"), "unset color should be omitted:\n{yaml}");
     }
 
     #[test]


### PR DESCRIPTION
Tick, bar and bubble plots wrote their unset `domain` and `color` as explicit `~` nulls; this adds `#[skip_serializing_none]` — which heatmaps and pills already use — so those fields are omitted and the config output stays clean.