### PR TITLE
feat: Add LLM based config generation via suggest subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -377,6 +377,12 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
@@ -744,6 +750,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crossterm"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
+dependencies = [
+ "bitflags 1.3.2",
+ "crossterm_winapi",
+ "libc",
+ "mio 0.8.11",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -876,6 +907,7 @@ dependencies = [
  "fancy-regex",
  "format_serde_error",
  "fs_extra",
+ "inquire",
  "itertools 0.15.0",
  "jsonm",
  "log",
@@ -886,6 +918,7 @@ dependencies = [
  "pyo3",
  "readervzrd",
  "reqwest",
+ "schemars 0.8.22",
  "serde",
  "serde_json",
  "serde_with",
@@ -898,6 +931,7 @@ dependencies = [
  "tera-contrib",
  "thiserror 2.0.20",
  "typed-builder",
+ "ureq",
 ]
 
 [[package]]
@@ -1042,7 +1076,7 @@ version = "25.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1045398c1bfd89168b5fd3f1fc11f6e70b34f6f66300c87d44d3de849463abf1"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
  "rustc_version",
 ]
 
@@ -1145,6 +1179,24 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -1538,6 +1590,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "inquire"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fddf93031af70e75410a2511ec04d49e758ed2f26dad3404a934e0fb45cc12a"
+dependencies = [
+ "bitflags 2.9.4",
+ "crossterm",
+ "dyn-clone",
+ "fuzzy-matcher",
+ "fxhash",
+ "newline-converter",
+ "once_cell",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
 name = "integer-encoding"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1549,7 +1618,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
  "cfg-if",
  "libc",
 ]
@@ -1807,7 +1876,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b407ca668368d1d5a86cea58ac82d9f9f9ca4bac1e9dce6f16f875f0f081a911"
 dependencies = [
  "ahash 0.8.12",
- "bitflags",
+ "bitflags 2.9.4",
  "const-str",
  "cssparser",
  "cssparser-color",
@@ -1860,11 +1929,10 @@ checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "lock_api"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
- "autocfg",
  "scopeguard",
 ]
 
@@ -1975,6 +2043,18 @@ dependencies = [
 
 [[package]]
 name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
@@ -1982,6 +2062,15 @@ dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "newline-converter"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b6b097ecb1cbfed438542d16e84fd7ad9b0c76c8a65b7f9039212a3d14dc7f"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -2134,7 +2223,7 @@ dependencies = [
  "textwrap",
  "thiserror 2.0.20",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -2167,7 +2256,7 @@ version = "0.95.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e78ea25d23521092edcd509198635dd0bd96df7fb71349bcd8087bb8f6a615d"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
  "oxc_allocator",
  "oxc_ast_macros",
  "oxc_data_structures",
@@ -2208,7 +2297,7 @@ version = "0.95.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "480bab938439c921d34750708abf15aacf253ea11e2f348e4b085cbf697f4ea2"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
  "cow-utils",
  "dragonbox_ecma",
  "itoa",
@@ -2332,7 +2421,7 @@ version = "0.95.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb730ab93ff23bbc471ef7109f847afa709bb284dd52a5d3366283d724858158"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
  "cow-utils",
  "memchr",
  "num-bigint",
@@ -2355,7 +2444,7 @@ version = "0.95.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27bafc3035e3b0fe555ae56f7bbc108a7ee520b0858250ba16d197e44ca83746"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
  "oxc_allocator",
  "oxc_ast_macros",
  "oxc_diagnostics",
@@ -2418,7 +2507,7 @@ version = "0.95.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93c99e555ed497111004a71fb2aa6f8fb90b0d3e2733aceeb035e24701d69634"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
  "cow-utils",
  "dragonbox_ecma",
  "nonmax",
@@ -2456,7 +2545,7 @@ version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54fd03f1ad26cb6b3ec1b7414fa78a3bd639e7dbb421b1a60513c96ce886a196"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
  "cssparser",
  "log",
  "phf 0.11.3",
@@ -2481,16 +2570,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "parking_lot_core"
-version = "0.9.11"
+name = "parking_lot"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.6",
+ "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -2982,7 +3081,7 @@ version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
 ]
 
 [[package]]
@@ -3153,7 +3252,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3167,7 +3266,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -3267,6 +3368,18 @@ dependencies = [
 
 [[package]]
 name = "schemars"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
@@ -3290,6 +3403,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars_derive"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2 1.0.106",
+ "quote 1.0.45",
+ "serde_derive_internals",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3307,7 +3432,7 @@ version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -3382,6 +3507,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+dependencies = [
+ "proc-macro2 1.0.106",
+ "quote 1.0.45",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3445,6 +3581,37 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio 0.8.11",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
 
 [[package]]
 name = "simd-abstraction"
@@ -3625,7 +3792,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -3701,7 +3868,7 @@ checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
 dependencies = [
  "smawk",
  "unicode-linebreak",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -3742,6 +3909,15 @@ dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.45",
  "syn 3.0.2",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -3832,7 +4008,7 @@ dependencies = [
  "bytes",
  "io-uring",
  "libc",
- "mio",
+ "mio 1.0.4",
  "pin-project-lite",
  "slab",
  "socket2",
@@ -3883,7 +4059,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
  "bytes",
  "futures-util",
  "http",
@@ -3984,6 +4160,12 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
@@ -4005,6 +4187,22 @@ name = "unty"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "url",
+ "webpki-roots 0.26.11",
+]
 
 [[package]]
 name = "url"
@@ -4200,6 +4398,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.9",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4207,6 +4439,12 @@ checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
 dependencies = [
  "windows-sys 0.60.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -4295,6 +4533,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -4333,6 +4580,21 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -4376,6 +4638,12 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -4394,6 +4662,12 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -4409,6 +4683,12 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4442,6 +4722,12 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -4457,6 +4743,12 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4478,6 +4770,12 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -4493,6 +4791,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ edition = "2021"
 fs_extra = "1.3.0"
 derefable = "0.1"
 serde = { version = "1", features = ["derive"] }
+schemars = "0.8"
+inquire = "0.7"
 clap = { version = "4.6.1", features = [
     "color",
     "suggestions",
@@ -48,6 +50,7 @@ tempfile = "3.27.0"
 
 [build-dependencies]
 fs_extra = "1.3"
+ureq = "2"
 
 [profile.release]
 codegen-units = 1

--- a/build.rs
+++ b/build.rs
@@ -2,9 +2,15 @@ use fs_extra::dir::CopyOptions;
 use std::env;
 use std::path::PathBuf;
 
+const DOCS_URL: &str = "https://raw.githubusercontent.com/datavzrd/datavzrd.github.io/refs/heads/main/src/docs/configuration.rst";
+
 fn main() {
     println!("cargo:rerun-if-changed=web/");
     let out_dir = env::var("OUT_DIR").unwrap();
+
+    let docs_path = PathBuf::from(&out_dir).join("configuration.rst");
+    std::fs::write(&docs_path, fetch_configuration_reference())
+        .expect("failed to write the configuration reference");
     let web_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("web");
     fs_extra::dir::copy(
         web_dir,
@@ -31,4 +37,22 @@ fn main() {
         .current_dir(work_dir.to_str().expect("failed to get work dir"))
         .status()
         .expect("failed to execute pnpm exec rspack build");
+}
+
+fn fetch_configuration_reference() -> String {
+    let mut last_error = String::new();
+    for attempt in 1..=5 {
+        match ureq::get(DOCS_URL).call() {
+            Ok(response) => {
+                return response
+                    .into_string()
+                    .expect("failed to read the configuration reference")
+            }
+            Err(error) => {
+                last_error = error.to_string();
+                std::thread::sleep(std::time::Duration::from_secs(attempt));
+            }
+        }
+    }
+    panic!("failed to fetch the configuration reference from {DOCS_URL}: {last_error}");
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -87,6 +87,24 @@ pub enum Command {
         /// Name of the report
         #[arg(short, long, default_value = "Datavzrd Report")]
         name: String,
+
+        /// Base URL of an OpenAI-compatible chat completions endpoint.
+        /// When given, the configuration is drafted by the LLM instead of the built-in heuristic.
+        #[arg(long, requires = "llm_model")]
+        llm_url: Option<String>,
+
+        /// Model to request from the LLM endpoint. Required when `--llm-url` is set.
+        #[arg(long)]
+        llm_model: Option<String>,
+
+        /// API token for the LLM endpoint, sent as a bearer token. Required by most hosted
+        /// providers and ignored by backends that do not need authentication.
+        #[arg(long, env = "DATAVZRD_LLM_TOKEN")]
+        llm_token: Option<String>,
+
+        /// Description of the desired report passed to the LLM backend. If omitted, it is requested interactively.
+        #[arg(short, long)]
+        prompt: Option<String>,
     },
 }
 

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -1,0 +1,187 @@
+use anyhow::{bail, Context, Result};
+use datavzrd::spec::RenderColumnSpec;
+use schemars::schema_for;
+use serde::Deserialize;
+use serde_json::{json, Map, Value};
+use std::collections::HashMap;
+use std::time::Duration;
+
+const DOCS: &str = include_str!(concat!(env!("OUT_DIR"), "/configuration.rst"));
+
+const PREAMBLE: &str = "You configure a datavzrd report from tabular data. For every column, decide how it should be rendered (plot, linkout, formatting, custom rendering, ...) and choose a short report name. Reply with a single JSON object of the form {\"report_name\": \"<name>\", \"columns\": {\"<exact column name>\": {<column configuration>}}}. Configure each column strictly according to the datavzrd configuration reference below. Add a link-to-url whenever a column clearly holds an identifier with a canonical web resource, choosing a fitting destination from the column's domain (e.g. gene symbol -> ClinVar or GeneCards, dbSNP rs id -> dbSNP, variant -> ClinVar, movie title -> IMDb, PubMed id -> PubMed, UniProt/Ensembl accession -> the respective database). Use only the exact column names given, and omit columns that need no special configuration.";
+
+pub(crate) struct LlmConfig {
+    pub url: String,
+    pub model: String,
+    pub token: Option<String>,
+    pub prompt: String,
+}
+
+pub(crate) struct ColumnContext {
+    pub name: String,
+    pub description: String,
+}
+
+#[derive(Deserialize)]
+pub(crate) struct Draft {
+    #[serde(default)]
+    pub report_name: Option<String>,
+    #[serde(default)]
+    pub columns: HashMap<String, Value>,
+}
+
+pub(crate) fn ask_prompt() -> Result<String> {
+    let description = inquire::Text::new("Describe how the report should look:")
+        .with_help_message("Guides how datavzrd renders each column")
+        .prompt()?;
+    if description.trim().is_empty() {
+        bail!("No prompt provided for the LLM backend.");
+    }
+    Ok(description)
+}
+
+/// Requests a report draft from the LLM endpoint for the given columns.
+pub(crate) fn request_draft(config: &LlmConfig, columns: &[ColumnContext]) -> Result<Draft> {
+    let column_list = columns
+        .iter()
+        .map(|column| format!("- {}: {}", column.name, column.description))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let system = format!("{PREAMBLE}\n\n=== datavzrd configuration reference ===\n{DOCS}");
+    let user = format!(
+        "Description of the desired report:\n{}\n\nColumns:\n{}\n\nReply with the JSON object.",
+        config.prompt, column_list
+    );
+    let body = json!({
+        "model": config.model,
+        "stream": false,
+        "temperature": 0,
+        "response_format": {
+            "type": "json_schema",
+            "json_schema": { "name": "datavzrd_report", "schema": schema(columns) }
+        },
+        "messages": [
+            { "role": "system", "content": system },
+            { "role": "user", "content": user },
+        ],
+    });
+    let endpoint = format!("{}/chat/completions", config.url.trim_end_matches('/'));
+    let client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(600))
+        .build()?;
+    let mut request = client
+        .post(&endpoint)
+        .header("content-type", "application/json");
+    if let Some(token) = &config.token {
+        request = request.bearer_auth(token);
+    }
+    let response = request
+        .body(body.to_string())
+        .send()
+        .with_context(|| format!("Could not reach the LLM endpoint at {endpoint}"))?;
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().unwrap_or_default();
+        bail!("The LLM endpoint returned status {status} for {endpoint}: {body}");
+    }
+    let chat: ChatResponse = serde_json::from_str(&response.text()?)
+        .context("Unexpected response from the LLM endpoint")?;
+    let content = chat
+        .choices
+        .into_iter()
+        .next()
+        .context("The LLM endpoint returned no choices")?
+        .message
+        .content;
+    serde_json::from_str(&content)
+        .context("The LLM endpoint did not return a valid JSON draft of the report")
+}
+
+fn schema(columns: &[ColumnContext]) -> Value {
+    let root = schema_for!(RenderColumnSpec);
+    let mut definitions = serde_json::to_value(&root.definitions).unwrap_or_else(|_| json!({}));
+    if let (Some(map), Ok(column_schema)) = (
+        definitions.as_object_mut(),
+        serde_json::to_value(&root.schema),
+    ) {
+        map.insert("RenderColumnSpec".to_string(), column_schema);
+    }
+    let column_properties: Map<String, Value> = columns
+        .iter()
+        .map(|column| {
+            (
+                column.name.clone(),
+                json!({ "$ref": "#/definitions/RenderColumnSpec" }),
+            )
+        })
+        .collect();
+    let mut schema = json!({
+        "type": "object",
+        "properties": {
+            "report_name": { "type": "string" },
+            "columns": {
+                "type": "object",
+                "properties": column_properties,
+                "additionalProperties": false
+            }
+        },
+        "required": ["columns"],
+        "definitions": definitions
+    });
+    flatten_single_all_of(&mut schema);
+    schema
+}
+
+// Guided-decoding backends often ignore constraints nested inside `allOf`, and schemars
+// wraps every field carrying a `#[serde(default)]` as `{ "default": …, "allOf": [<schema>] }`.
+// Replacing such nodes with their single inner schema restores enforcement.
+fn flatten_single_all_of(value: &mut Value) {
+    match value {
+        Value::Object(map) => {
+            if let Some(Value::Array(items)) = map.get("allOf") {
+                if items.len() == 1 {
+                    *value = items[0].clone();
+                    flatten_single_all_of(value);
+                    return;
+                }
+            }
+            map.values_mut().for_each(flatten_single_all_of);
+        }
+        Value::Array(items) => items.iter_mut().for_each(flatten_single_all_of),
+        _ => {}
+    }
+}
+
+#[derive(Deserialize)]
+struct ChatResponse {
+    choices: Vec<ChatChoice>,
+}
+
+#[derive(Deserialize)]
+struct ChatChoice {
+    message: ChatMessage,
+}
+
+#[derive(Deserialize)]
+struct ChatMessage {
+    content: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn flatten_single_all_of_unwraps_and_keeps_multi() {
+        // A single-element `allOf` wrapper is replaced by its inner schema.
+        let mut single = json!({ "field": { "default": 1, "allOf": [{ "type": "integer" }] } });
+        flatten_single_all_of(&mut single);
+        assert_eq!(single, json!({ "field": { "type": "integer" } }));
+
+        // An `allOf` with several entries is left untouched.
+        let mut multi = json!({ "allOf": [{ "type": "string" }, { "minLength": 1 }] });
+        let untouched = multi.clone();
+        flatten_single_all_of(&mut multi);
+        assert_eq!(multi, untouched);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ use simplelog::{ColorChoice, Config, TermLogger, TerminalMode};
 use std::io::{stdout, Write};
 
 pub(crate) mod cli;
+mod llm;
 pub(crate) mod publish;
 mod suggest;
 
@@ -33,11 +34,30 @@ fn main() -> Result<()> {
             files,
             separators,
             name,
+            llm_url,
+            llm_model,
+            llm_token,
+            prompt,
         }) => {
             if files.len() != separators.len() {
                 bail!(CliError::MismatchedSeparators);
             }
-            let config = suggest::suggest(files, separators, name)?;
+            let llm = match (llm_url, llm_model) {
+                (Some(url), Some(model)) => {
+                    let prompt = match prompt {
+                        Some(prompt) => prompt,
+                        None => llm::ask_prompt()?,
+                    };
+                    Some(llm::LlmConfig {
+                        url,
+                        model,
+                        token: llm_token,
+                        prompt,
+                    })
+                }
+                _ => None,
+            };
+            let config = suggest::suggest(files, separators, name, llm)?;
             stdout().write_all(config.as_bytes())?;
         }
         None => {

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -17,6 +17,7 @@ use itertools::Itertools;
 
 use crate::spells::SpellSpec;
 use format_serde_error::SerdeError;
+use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
 use serde_with::skip_serializing_none;
@@ -52,6 +53,18 @@ pub struct ItemsSpec {
 }
 
 impl ItemsSpec {
+    pub fn new(report_name: String) -> Self {
+        ItemsSpec {
+            report_name,
+            datasets: HashMap::new(),
+            default_view: None,
+            max_in_memory_rows: default_single_page_threshold(),
+            views: HashMap::new(),
+            aux_libraries: None,
+            webview_controls: false,
+        }
+    }
+
     pub fn from_file<P: AsRef<Path> + Debug>(path: P) -> Result<ItemsSpec> {
         let config_file = fs::read_to_string(&path).context(format!(
             "Could not find config file under given path {:?}",
@@ -62,10 +75,15 @@ impl ItemsSpec {
         }
         let mut items_spec: ItemsSpec = serde_yaml::from_str(&config_file)
             .map_err(|err| SerdeError::new(config_file.to_string(), err))?;
-        for dataset in items_spec.datasets.values_mut() {
+        items_spec.preprocess()?;
+        Ok(items_spec)
+    }
+
+    pub fn preprocess(&mut self) -> Result<()> {
+        for dataset in self.datasets.values_mut() {
             dataset.preprocess()?;
         }
-        for (name, dataset) in &items_spec.datasets {
+        for (name, dataset) in &self.datasets {
             let lines = dataset
                 .reader()?
                 .records()?
@@ -81,7 +99,7 @@ impl ItemsSpec {
                 })
             }
         }
-        for (name, spec) in items_spec.views.iter_mut() {
+        for (name, spec) in self.views.iter_mut() {
             if let Some(spell) = spec.spell.as_ref() {
                 let rendered_spec = spell.render_item_spec()?;
                 *spec = spec.merge_item_specs(&rendered_spec)?;
@@ -97,7 +115,7 @@ impl ItemsSpec {
                         view: name.to_string()
                     })
                 };
-                let dataset = match items_spec.datasets.get(dataset_name) {
+                let dataset = match self.datasets.get(dataset_name) {
                     Some(dataset) => dataset,
                     None => {
                         bail!(DatasetError::NotFound {
@@ -105,10 +123,10 @@ impl ItemsSpec {
                         })
                     }
                 };
-                spec.preprocess_columns(dataset, items_spec.max_in_memory_rows)?;
+                spec.preprocess_columns(dataset, self.max_in_memory_rows)?;
             }
         }
-        Ok(items_spec)
+        Ok(())
     }
 
     pub fn needs_excel_sheet(&self) -> bool {
@@ -228,10 +246,19 @@ impl ItemsSpec {
                                     })
                                 }
                             }
+                            if let Some(custom_plot) = &render_columns.custom_plot {
+                                if let Some(spec) = custom_plot.schema.as_deref() {
+                                    if serde_json::from_str::<serde_json::Value>(spec).is_err() {
+                                        bail!(ConfigError::InvalidCustomPlotSpec {
+                                            view: name.to_string(),
+                                            column: column.to_string(),
+                                        })
+                                    }
+                                }
+                            }
                             if let Some(plot_spec) = &render_columns.plot {
                                 if let Some(pills) = &plot_spec.pills {
-                                    if pills.color_scheme.is_empty()
-                                        && pills.color_range.0.is_empty()
+                                    if pills.color_scheme.is_empty() && pills.color_range.is_empty()
                                     {
                                         bail!(ConfigError::PillsMissingColorDefinition {
                                             view: name.to_string(),
@@ -832,7 +859,7 @@ fn default_precision() -> u32 {
 }
 
 #[skip_serializing_none]
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[derive(JsonSchema, Deserialize, Serialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct RenderColumnSpec {
     #[serde(default, skip_serializing_if = "is_default_flag")]
@@ -935,7 +962,7 @@ impl RenderColumnSpec {
     }
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[derive(JsonSchema, Deserialize, Serialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 pub struct LinkToUrlSpec {
     #[serde(flatten)]
@@ -943,7 +970,7 @@ pub struct LinkToUrlSpec {
     pub custom_content: Option<String>,
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[derive(JsonSchema, Deserialize, Serialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct LinkToUrlSpecEntry {
     url: String,
@@ -955,7 +982,7 @@ fn default_new_window() -> bool {
     true
 }
 
-#[derive(Default, Deserialize, Serialize, Debug, Clone, PartialEq, Copy)]
+#[derive(JsonSchema, Default, Deserialize, Serialize, Debug, Clone, PartialEq, Copy)]
 #[serde(rename_all = "lowercase")]
 pub enum DisplayMode {
     #[default]
@@ -1135,7 +1162,7 @@ impl LinkSpec {
     }
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[derive(JsonSchema, Deserialize, Serialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct CustomPlot {
     #[serde(default, rename = "data")]
@@ -1164,7 +1191,7 @@ impl CustomPlot {
 }
 
 #[skip_serializing_none]
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[derive(JsonSchema, Deserialize, Serialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct PlotSpec {
     #[serde(rename = "ticks")]
@@ -1178,8 +1205,31 @@ pub struct PlotSpec {
     pub bubble_plot: Option<BubblePlot>,
 }
 
+impl PlotSpec {
+    pub fn heatmap(scale_type: ScaleType, color_scheme: String, color_range: ColorRange) -> Self {
+        PlotSpec {
+            tick_plot: None,
+            heatmap: Some(Heatmap {
+                vega_type: None,
+                scale_type,
+                clamp: default_clamp(),
+                color_scheme,
+                color_range,
+                domain: None,
+                domain_mid: None,
+                aux_domain_columns: AuxDomainColumns(None),
+                custom_content: None,
+                legend: None,
+            }),
+            bar_plot: None,
+            pills: None,
+            bubble_plot: None,
+        }
+    }
+}
+
 #[skip_serializing_none]
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[derive(JsonSchema, Deserialize, Serialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct PillsSpec {
     #[serde(default = "default_pill_separator")]
@@ -1254,7 +1304,7 @@ impl PillsSpec {
 }
 
 #[skip_serializing_none]
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[derive(JsonSchema, Deserialize, Serialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct BubblePlot {
     #[serde(default, rename = "scale")]
@@ -1277,7 +1327,7 @@ impl BubblePlot {
 }
 
 #[skip_serializing_none]
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[derive(JsonSchema, Deserialize, Serialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct TickPlot {
     #[serde(default, rename = "scale")]
@@ -1290,7 +1340,7 @@ pub struct TickPlot {
     pub color: Option<ColorDefinition>,
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[derive(JsonSchema, Deserialize, Serialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct ColorDefinition {
     #[serde(default, rename = "scale")]
@@ -1350,7 +1400,7 @@ fn is_default_in_memory_rows(value: &usize) -> bool {
 }
 
 #[skip_serializing_none]
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[derive(JsonSchema, Deserialize, Serialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct Heatmap {
     #[serde(default, rename = "type")]
@@ -1379,12 +1429,12 @@ pub struct Heatmap {
     pub legend: Option<LegendSpec>,
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Default)]
+#[derive(JsonSchema, Deserialize, Serialize, Debug, Clone, PartialEq, Default)]
 pub struct LegendSpec {
     pub title: String,
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Default)]
+#[derive(JsonSchema, Deserialize, Serialize, Debug, Clone, PartialEq, Default)]
 pub struct ColorRange(pub Vec<Color>);
 
 impl ColorRange {
@@ -1397,7 +1447,7 @@ impl ColorRange {
     }
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[derive(JsonSchema, Deserialize, Serialize, Debug, Clone, PartialEq)]
 pub struct Color(pub String);
 
 impl Color {
@@ -1528,7 +1578,7 @@ impl SequentialScheme {
 }
 
 #[skip_serializing_none]
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[derive(JsonSchema, Deserialize, Serialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct BarPlot {
     #[serde(default, rename = "scale")]
@@ -1541,7 +1591,7 @@ pub struct BarPlot {
     pub color: Option<ColorDefinition>,
 }
 
-#[derive(Default, Deserialize, Serialize, Debug, Clone, PartialEq, Copy)]
+#[derive(JsonSchema, Default, Deserialize, Serialize, Debug, Clone, PartialEq, Copy)]
 #[serde(rename_all = "lowercase")]
 pub enum ScaleType {
     Linear,
@@ -1559,7 +1609,7 @@ pub enum ScaleType {
     None,
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Copy)]
+#[derive(JsonSchema, Deserialize, Serialize, Debug, Clone, PartialEq, Copy)]
 #[serde(rename_all = "lowercase")]
 pub enum VegaType {
     Nominal,
@@ -1587,7 +1637,7 @@ impl ScaleType {
     }
 }
 
-#[derive(Default, Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+#[derive(JsonSchema, Default, Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 pub struct AuxDomainColumns(pub Option<Vec<String>>);
 
 impl AuxDomainColumns {
@@ -1647,6 +1697,8 @@ pub enum ConfigError {
     },
     #[error("The link-to-url definition of column {column:?} in view {view:?} does not define any URL. Please provide at least one named link with a url.")]
     LinkToUrlMissingUrl { view: String, column: String },
+    #[error("The custom-plot spec of column {column:?} in view {view:?} is not valid JSON. Please provide a valid Vega-Lite specification.")]
+    InvalidCustomPlotSpec { view: String, column: String },
     #[error("Could not find column with index {index:?} under path {table_path:?} with only {header_length:?} columns.")]
     IndexTooLarge {
         index: usize,

--- a/src/spells.rs
+++ b/src/spells.rs
@@ -6,6 +6,7 @@ use pyo3::prelude::*;
 use pyo3::types::IntoPyDict;
 use pyo3::types::PyModule;
 use reqwest::blocking::get;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
@@ -14,7 +15,7 @@ use std::sync::LazyLock;
 use std::sync::Mutex;
 use std::{thread::sleep, time::Duration};
 
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[derive(JsonSchema, Deserialize, Serialize, Debug, Clone, PartialEq)]
 #[serde(rename_all(deserialize = "kebab-case"), deny_unknown_fields)]
 pub struct SpellSpec {
     pub url: String,

--- a/src/suggest.rs
+++ b/src/suggest.rs
@@ -1,23 +1,24 @@
-use anyhow::Result;
+use crate::llm::{self, ColumnContext, Draft, LlmConfig};
+use anyhow::{Context, Result};
 use datavzrd::spec::{
-    default_page_size, default_single_page_threshold, AuxDomainColumns, Color, ColorRange,
-    DatasetSpecs, Heatmap, ItemSpecs, ItemsSpec, PlotSpec, RenderColumnSpec, RenderTableSpecs,
-    ScaleType,
+    default_page_size, Color, ColorRange, DatasetSpecs, ItemSpecs, ItemsSpec, PlotSpec,
+    RenderColumnSpec, RenderTableSpecs, ScaleType,
 };
-use datavzrd::utils::column_type::ColumnType;
+use datavzrd::utils::column_type::{ColumnType, IsNa};
+use log::warn;
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-pub(crate) fn suggest(files: Vec<PathBuf>, separator: Vec<char>, name: String) -> Result<String> {
-    let mut items_spec = ItemsSpec {
-        report_name: name,
-        datasets: HashMap::new(),
-        default_view: None,
-        max_in_memory_rows: default_single_page_threshold(),
-        views: HashMap::new(),
-        aux_libraries: None,
-        webview_controls: false,
-    };
+const MAX_EXAMPLES: usize = 2;
+const EXAMPLE_MAX_CHARS: usize = 25;
+
+pub(crate) fn suggest(
+    files: Vec<PathBuf>,
+    separator: Vec<char>,
+    name: String,
+    llm: Option<LlmConfig>,
+) -> Result<String> {
+    let mut items_spec = ItemsSpec::new(name);
     for (file, sep) in files.iter().zip(separator.iter()) {
         let dataset = DatasetSpecs {
             path: file.to_owned(),
@@ -26,86 +27,227 @@ pub(crate) fn suggest(files: Vec<PathBuf>, separator: Vec<char>, name: String) -
             links: None,
             offer_excel: false,
         };
-        let dataset_name = file.file_stem().unwrap().to_str().unwrap().to_string();
+        let dataset_name = file
+            .file_stem()
+            .and_then(|stem| stem.to_str())
+            .with_context(|| format!("Could not derive a dataset name from {}", file.display()))?
+            .to_string();
         items_spec
             .datasets
-            .insert(dataset_name.to_string(), dataset.clone());
+            .insert(dataset_name.clone(), dataset.clone());
         let column_types = datavzrd::utils::column_type::classify_table(&dataset, true)?;
-        let mut columns = HashMap::new();
-        for (column_name, column_type) in column_types.iter() {
-            let render_column_spec = match column_type {
-                ColumnType::None => RenderColumnSpec::default(),
-                ColumnType::String => RenderColumnSpec {
-                    plot: Some(PlotSpec {
-                        tick_plot: None,
-                        heatmap: Some(Heatmap {
-                            vega_type: None,
-                            scale_type: ScaleType::Ordinal,
-                            clamp: true,
-                            color_scheme: "category20".to_string(),
-                            color_range: Default::default(),
-                            domain: None,
-                            domain_mid: None,
-                            aux_domain_columns: AuxDomainColumns(None),
-                            custom_content: None,
-                            legend: None,
-                        }),
-                        bar_plot: None,
-                        pills: None,
-                        bubble_plot: None,
-                    }),
-                    ..RenderColumnSpec::default()
-                },
-                ColumnType::Integer | ColumnType::Float => RenderColumnSpec {
-                    plot: Some(PlotSpec {
-                        tick_plot: None,
-                        heatmap: Some(Heatmap {
-                            vega_type: None,
-                            scale_type: ScaleType::Linear,
-                            clamp: true,
-                            color_scheme: "".to_string(),
-                            color_range: ColorRange(vec![
-                                Color("white".to_string()),
-                                Color("blue".to_string()),
-                            ]),
-                            domain: None,
-                            domain_mid: None,
-                            aux_domain_columns: AuxDomainColumns(None),
-                            custom_content: None,
-                            legend: None,
-                        }),
-                        bar_plot: None,
-                        pills: None,
-                        bubble_plot: None,
-                    }),
-                    ..RenderColumnSpec::default()
-                },
-            };
-            columns.insert(column_name.to_string(), render_column_spec);
+        let mut columns: HashMap<String, RenderColumnSpec> = column_types
+            .iter()
+            .map(|(name, column_type)| (name.to_string(), baseline_column(column_type)))
+            .collect();
+        if let Some(llm) = &llm {
+            let contexts = build_contexts(&dataset, &column_types)?;
+            // Retry once
+            let draft = llm::request_draft(llm, &contexts)
+                .or_else(|_| llm::request_draft(llm, &contexts))?;
+            apply_draft(
+                draft,
+                &mut items_spec.report_name,
+                &dataset_name,
+                &dataset,
+                &column_types,
+                &mut columns,
+            );
         }
-        let render_table = RenderTableSpecs {
+        items_spec
+            .views
+            .insert(dataset_name.clone(), make_view(&dataset_name, columns));
+    }
+    Ok(serde_yaml::to_string(&items_spec)?)
+}
+
+fn apply_draft(
+    draft: Draft,
+    report_name: &mut String,
+    dataset_name: &str,
+    dataset: &DatasetSpecs,
+    column_types: &HashMap<String, ColumnType>,
+    columns: &mut HashMap<String, RenderColumnSpec>,
+) {
+    if let Some(name) = draft.report_name.filter(|name| !name.trim().is_empty()) {
+        *report_name = name;
+    }
+    let suggested: Vec<(String, RenderColumnSpec)> = draft
+        .columns
+        .into_iter()
+        .filter_map(|(name, value)| {
+            if !columns.contains_key(&name) {
+                warn!("ignoring suggestion for unknown column {name:?}");
+                return None;
+            }
+            match serde_json::from_value(value) {
+                Ok(mut spec) => {
+                    fill_default_colors(&mut spec, &column_types[&name]);
+                    Some((name, spec))
+                }
+                Err(error) => {
+                    warn!("column {name:?} fell back to the default because its suggested configuration could not be parsed: {error}");
+                    None
+                }
+            }
+        })
+        .collect();
+
+    // Keep each suggestion only if it still validates alongside the rest, else revert to the baseline column.
+    for (name, spec) in suggested {
+        let baseline = columns.insert(name.clone(), spec);
+        if validate_columns(report_name, dataset_name, dataset, columns).is_err() {
+            let rejected = serde_yaml::to_string(&columns[&name]).unwrap_or_default();
+            warn!("column {name:?} fell back to the default because its suggested configuration was invalid. The rejected configuration was:\n{rejected}");
+            if let Some(baseline) = baseline {
+                columns.insert(name, baseline);
+            }
+        }
+    }
+}
+
+fn validate_columns(
+    report_name: &str,
+    dataset_name: &str,
+    dataset: &DatasetSpecs,
+    columns: &HashMap<String, RenderColumnSpec>,
+) -> Result<()> {
+    let mut items_spec = ItemsSpec::new(report_name.to_string());
+    items_spec
+        .datasets
+        .insert(dataset_name.to_string(), dataset.clone());
+    items_spec.views.insert(
+        dataset_name.to_string(),
+        make_view(dataset_name, columns.clone()),
+    );
+    items_spec.preprocess()?;
+    items_spec.validate()
+}
+
+fn make_view(dataset_name: &str, columns: HashMap<String, RenderColumnSpec>) -> ItemSpecs {
+    ItemSpecs {
+        hidden: false,
+        narrow: false,
+        dataset: Some(dataset_name.to_string()),
+        datasets: None,
+        page_size: default_page_size(),
+        single_page_page_size: default_page_size(),
+        description: None,
+        render_table: Some(RenderTableSpecs {
             columns,
             additional_columns: None,
             headers: None,
-        };
-        let item_spec = ItemSpecs {
-            hidden: false,
-            narrow: false,
-            dataset: Some(dataset_name.to_string()),
-            datasets: None,
-            page_size: default_page_size(),
-            single_page_page_size: default_page_size(),
-            description: None,
-            render_table: Some(render_table),
-            render_plot: None,
-            render_html: None,
-            render_img: None,
-            max_in_memory_rows: None,
-            spell: None,
-        };
-        items_spec.views.insert(dataset_name.to_string(), item_spec);
+        }),
+        render_plot: None,
+        render_html: None,
+        render_img: None,
+        max_in_memory_rows: None,
+        spell: None,
     }
-    Ok(serde_yaml::to_string(&items_spec)?)
+}
+
+fn build_contexts(
+    dataset: &DatasetSpecs,
+    column_types: &HashMap<String, ColumnType>,
+) -> Result<Vec<ColumnContext>> {
+    let mut reader = dataset.reader()?;
+    let headers = reader.headers()?.clone();
+    let mut examples: HashMap<String, Vec<String>> = headers
+        .iter()
+        .map(|h| (h.to_string(), Vec::new()))
+        .collect();
+    let mut ranges: HashMap<String, (f64, f64)> = HashMap::new();
+    for record in reader.records()?.skip(dataset.header_rows - 1) {
+        for (header, value) in headers.iter().zip(record.iter()) {
+            if value.is_na() {
+                continue;
+            }
+            let seen = examples.get_mut(header).unwrap();
+            if seen.len() < MAX_EXAMPLES && !seen.iter().any(|example| example == value) {
+                seen.push(value.to_string());
+            }
+            if let Ok(number) = value.parse::<f64>() {
+                let range = ranges.entry(header.to_string()).or_insert((number, number));
+                range.0 = range.0.min(number);
+                range.1 = range.1.max(number);
+            }
+        }
+    }
+    Ok(headers
+        .iter()
+        .map(|header| {
+            let mut description = column_types[header].to_string();
+            if let Some((min, max)) = ranges.get(header) {
+                description += &format!(", range {min}..{max}");
+            }
+            let seen = &examples[header];
+            if !seen.is_empty() {
+                let previews = seen
+                    .iter()
+                    .map(|value| {
+                        let preview: String = value.chars().take(EXAMPLE_MAX_CHARS).collect();
+                        if value.chars().count() > EXAMPLE_MAX_CHARS {
+                            format!("{preview}…")
+                        } else {
+                            preview
+                        }
+                    })
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                description += &format!(", e.g. {previews}");
+            }
+            ColumnContext {
+                name: header.to_string(),
+                description,
+            }
+        })
+        .collect())
+}
+
+fn baseline_column(column_type: &ColumnType) -> RenderColumnSpec {
+    let plot = match column_type {
+        ColumnType::None => None,
+        ColumnType::String => Some(PlotSpec::heatmap(
+            ScaleType::Ordinal,
+            "category20".to_string(),
+            ColorRange::default(),
+        )),
+        ColumnType::Integer | ColumnType::Float => Some(PlotSpec::heatmap(
+            ScaleType::Linear,
+            String::new(),
+            ColorRange(vec![Color("white".to_string()), Color("blue".to_string())]),
+        )),
+    };
+    RenderColumnSpec {
+        plot,
+        ..RenderColumnSpec::default()
+    }
+}
+
+/// Completes a suggested pills or heatmap plot that the model left uncolored with a
+/// sensible default scheme (`category20` for categorical values, `blues` for numeric
+/// ones), so the model's feature choice survives validation instead of falling back.
+fn fill_default_colors(spec: &mut RenderColumnSpec, column_type: &ColumnType) {
+    let Some(plot) = spec.plot.as_mut() else {
+        return;
+    };
+    if let Some(pills) = plot.pills.as_mut() {
+        if pills.color_scheme.is_empty() && pills.color_range.0.is_empty() {
+            pills.color_scheme = "category20".to_string();
+        }
+    }
+    if let Some(heatmap) = plot.heatmap.as_mut() {
+        if heatmap.vega_type.is_none()
+            && heatmap.color_scheme.is_empty()
+            && heatmap.color_range.0.is_empty()
+        {
+            heatmap.color_scheme = match column_type {
+                ColumnType::Integer | ColumnType::Float => "blues",
+                _ => "category20",
+            }
+            .to_string();
+        }
+    }
 }
 
 #[cfg(test)]
@@ -123,12 +265,115 @@ mod tests {
         ];
         let separators = vec![',', ','];
         let name = "Test Report".to_string();
-        let result = suggest(files, separators, name);
+        let result = suggest(files, separators, name, None);
         assert!(result.is_ok());
         let tmp = tempfile::NamedTempFile::new()?;
         tmp.as_file().write_all(result.unwrap().as_bytes())?;
         let config = ItemsSpec::from_file(tmp.path())?;
         assert!(config.validate().is_ok());
         Ok(())
+    }
+
+    fn movies() -> (
+        DatasetSpecs,
+        HashMap<String, ColumnType>,
+        HashMap<String, RenderColumnSpec>,
+    ) {
+        let dataset = DatasetSpecs {
+            path: PathBuf::from(".examples/data/movies.csv"),
+            separator: ',',
+            header_rows: 1,
+            links: None,
+            offer_excel: false,
+        };
+        let column_types = datavzrd::utils::column_type::classify_table(&dataset, true).unwrap();
+        let columns = column_types
+            .iter()
+            .map(|(name, column_type)| (name.to_string(), baseline_column(column_type)))
+            .collect();
+        (dataset, column_types, columns)
+    }
+
+    #[test]
+    fn apply_draft_updates_name_and_ignores_unknown_columns() {
+        let (dataset, column_types, mut columns) = movies();
+        let baseline = columns.clone();
+        let draft = Draft {
+            report_name: Some("New Name".to_string()),
+            columns: HashMap::from([(
+                "totally_unknown".to_string(),
+                serde_json::json!({ "display-mode": "hidden" }),
+            )]),
+        };
+        let mut name = "Old".to_string();
+        apply_draft(
+            draft,
+            &mut name,
+            "movies",
+            &dataset,
+            &column_types,
+            &mut columns,
+        );
+        assert_eq!(name, "New Name");
+        assert_eq!(columns, baseline);
+    }
+
+    #[test]
+    fn apply_draft_reverts_invalid_suggestion_to_baseline() {
+        let (dataset, column_types, mut columns) = movies();
+        let target = columns.keys().next().unwrap().clone();
+        let baseline = columns[&target].clone();
+        // A link-to-url with only custom-content and no url is invalid and cannot be
+        // auto-completed, so the column must fall back to its baseline.
+        let draft = Draft {
+            report_name: None,
+            columns: HashMap::from([(
+                target.clone(),
+                serde_json::json!({
+                    "link-to-url": { "custom-content": "function(value, row) { return value; }" }
+                }),
+            )]),
+        };
+        let mut name = "keep".to_string();
+        apply_draft(
+            draft,
+            &mut name,
+            "movies",
+            &dataset,
+            &column_types,
+            &mut columns,
+        );
+        assert_eq!(name, "keep");
+        assert_eq!(columns[&target], baseline);
+    }
+
+    #[test]
+    fn apply_draft_auto_fills_missing_pills_color() {
+        let (dataset, column_types, mut columns) = movies();
+        let target = columns.keys().next().unwrap().clone();
+        // Pills without a color would be rejected; the auto-fill completes them so the
+        // model's pills choice is kept instead of falling back.
+        let draft = Draft {
+            report_name: None,
+            columns: HashMap::from([(
+                target.clone(),
+                serde_json::json!({ "plot": { "pills": { "separator": ";" } } }),
+            )]),
+        };
+        let mut name = "keep".to_string();
+        apply_draft(
+            draft,
+            &mut name,
+            "movies",
+            &dataset,
+            &column_types,
+            &mut columns,
+        );
+        let pills = columns[&target]
+            .plot
+            .as_ref()
+            .and_then(|plot| plot.pills.as_ref())
+            .expect("pills should be kept, not dropped");
+        assert!(!pills.color_scheme.is_empty());
     }
 }

--- a/src/utils/column_type.rs
+++ b/src/utils/column_type.rs
@@ -48,6 +48,18 @@ impl ColumnType {
     }
 }
 
+impl std::fmt::Display for ColumnType {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let label = match self {
+            ColumnType::None => "empty",
+            ColumnType::String => "text",
+            ColumnType::Integer => "integer",
+            ColumnType::Float => "float",
+        };
+        write!(f, "{label}")
+    }
+}
+
 /// Classifies table columns as String, Integer or Float
 /// The warn parameter controls whether warnings are printed to the console.
 pub fn classify_table(dataset: &DatasetSpecs, warn: bool) -> Result<HashMap<String, ColumnType>> {
@@ -72,13 +84,14 @@ pub fn classify_table(dataset: &DatasetSpecs, warn: bool) -> Result<HashMap<Stri
     Ok(classification)
 }
 
-pub(crate) trait IsNa {
+pub trait IsNa {
     fn is_na(&self) -> bool;
 }
 
-impl IsNa for &str {
+impl<T: AsRef<str> + ?Sized> IsNa for T {
     fn is_na(&self) -> bool {
-        self.is_empty() || self == &"NA"
+        let value = self.as_ref();
+        value.is_empty() || value == "NA"
     }
 }
 


### PR DESCRIPTION
This PR completely updates the `datavzrd suggest` subcommand adding the option for provide an openai compatible endpoint for config generation. Whenever the LLM doesn't provide a valid config for a column it falls back to the default config from the previous heuristic way the `suggest` command  worked. This ensures all configuration generated are valid and ready to use.