### PR TITLE
perf: Use mimalloc as the global allocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -924,6 +924,7 @@ dependencies = [
  "log",
  "lz-str",
  "md5",
+ "mimalloc",
  "minify-html",
  "minify-js",
  "pyo3",
@@ -1891,6 +1892,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "libz-rs-sys"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2016,6 +2026,15 @@ name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "mimalloc"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
+dependencies = [
+ "libmimalloc-sys",
+]
 
 [[package]]
 name = "mime"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,10 @@ format_serde_error = "0.3.0"
 reqwest = { version = "0.13.4", features = ["blocking"] }
 pyo3 = { version = "0.29.0", features = ["auto-initialize", "abi3-py310"] }
 tempfile = "3.27.0"
+mimalloc = { version = "0.1", optional = true }
+
+[features]
+default = ["mimalloc"]
 
 [build-dependencies]
 fs_extra = "1.3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,10 @@ mod llm;
 pub(crate) mod publish;
 mod suggest;
 
+#[cfg(feature = "mimalloc")]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 fn main() -> Result<()> {
     let opt = cli::Datavzrd::parse();
     let _ = TermLogger::init(


### PR DESCRIPTION
datavzrd makes millions of small allocations while rendering and the system allocator holds onto the freed memory, so peak RSS on large reports grows far beyond the live data. Switching to mimalloc roughly halved peak RSS on a 1M row report (3.4 GB down to 1.7 GB) and cut render time by about a third, and it sits behind a default feature so a target that can't build it can opt out with --no-default-features.
