### PR TITLE
build(deps): Update jsonm to 0.2.3 and readervzrd to 0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1757,11 +1757,10 @@ checksum = "a3c2a6c0b4b5637c41719973ef40c6a1cf564f9db6958350de6193fbee9c23f5"
 
 [[package]]
 name = "jsonm"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b86792f3504fd604d10f67b87c0db3514df881542e22e4c46af9031dcce3262"
+checksum = "374a829cb5c1bd749ab5bda2fbe3f579d056db918b0cec72f20d661088e71588"
 dependencies = [
- "regex",
  "serde",
  "serde_json",
 ]
@@ -3022,18 +3021,6 @@ dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.45",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "regex"
-version = "1.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
-dependencies = [
- "aho-corasick 1.1.3",
- "memchr",
- "regex-automata",
- "regex-syntax",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ clap = { version = "4.6.1", features = [
 ] }
 anyhow = "1"
 thiserror = "2"
-readervzrd = "0.4.0"
+readervzrd = "0.4.1"
 typed-builder = "0.23"
 serde_yaml = "0.8" # https://github.com/AlexanderThaller/format_serde_error/pull/23
 serde_with = { version = "3.20.0", features = ["macros"] }
@@ -42,7 +42,7 @@ minify-html = "0.18.1"
 simple_excel_writer = "0.2"
 slug = "0.1.6"
 md5 = "0.8.0"
-jsonm = "0.2.2"
+jsonm = "0.2.3"
 format_serde_error = "0.3.0"
 reqwest = { version = "0.13.4", features = ["blocking"] }
 pyo3 = { version = "0.29.0", features = ["auto-initialize", "abi3-py310"] }


### PR DESCRIPTION
jsonm 0.2.3 removes the per-value regex recompilation that dominated compress runtime on large tables. This bumps jsonm and readervzrd in both Cargo.toml and Cargo.lock so the manifests match the versions actually in use.
