### PR TITLE
perf: Store only values in the search index

### DIFF
--- a/src/render/portable/mod.rs
+++ b/src/render/portable/mod.rs
@@ -1366,18 +1366,13 @@ fn render_search_dialogs<P: AsRef<Path>>(
         if table_classes.get(title).unwrap() != &ColumnType::Float {
             let mut reader = dataset.reader()?;
 
-            let row_address_factory = RowAddressFactory::new(page_size);
-
-            let records = &reader
+            let values = reader
                 .records()?
                 .skip(dataset.header_rows - 1)
                 .map(|row| row.get(column).unwrap().to_string())
-                .enumerate()
-                .map(|(i, row)| (row, row_address_factory.get(i)))
-                .map(|(row, address)| (row, address.page + 1, address.row))
                 .collect_vec();
 
-            let compressed_data = compress(json!(records), debug)?;
+            let compressed_data = compress(json!(values), debug)?;
 
             let mut templates = Tera::default();
             templates.add_raw_template(
@@ -1386,7 +1381,7 @@ fn render_search_dialogs<P: AsRef<Path>>(
             )?;
             let mut context = Context::new();
             context.insert("data", &compressed_data);
-            context.insert("records", &records);
+            context.insert("page_size", &page_size);
             context.insert("title", &title);
 
             let file_path = Path::new(&output_path)

--- a/templates/search_dialog.html.tera
+++ b/templates/search_dialog.html.tera
@@ -10,6 +10,7 @@
 <script>
     const search_data = {{ data | safe }};
     const table_title = "{{ title }}";
+    const page_size = {{ page_size }};
     datavzrd.load_search();
 </script>
 <div class="container-fluid">

--- a/web/src/datavzrd.js
+++ b/web/src/datavzrd.js
@@ -1457,10 +1457,11 @@ export function load_search() {
     let decompressed = decompress(search_data);
     let table_data = [];
     for (var i = 0; i < decompressed.length; i++) {
-      var row = decompressed[i];
+      var page = Math.floor(i / page_size) + 1;
+      var highlight = i % page_size;
       table_data.push({
-        page: `<a target="_parent" href="../index_${row[1]}.html?highlight=${row[2]}" style="display: table-cell">${row[1]}</a>`,
-        title: row[0],
+        page: `<a target="_parent" href="../index_${page}.html?highlight=${highlight}" style="display: table-cell">${page}</a>`,
+        title: decompressed[i],
       });
     }
     $("#search-table").bootstrapTable({


### PR DESCRIPTION
The per-column search index stored a (value, page, row) triple for every row, and building it was the largest single chunk of peak memory on big multi-page tables. The rows are already in order, so this stores just the values and lets the client work out page and row from the array index. On a 1M row report that drops peak memory from about 1.7 GB to 640 MB and takes roughly a third off the render time.
