### PR TITLE
perf: Compute per-column overview data in a single pass

### DIFF
--- a/src/render/portable/mod.rs
+++ b/src/render/portable/mod.rs
@@ -1,9 +1,10 @@
 mod plot;
 pub(crate) mod utils;
-use crate::render::portable::plot::get_min_max;
 use crate::render::portable::plot::render_plots;
+use crate::render::portable::plot::{column_batch_size, read_columns};
 use crate::render::portable::utils::escape_html_string;
 use crate::render::portable::utils::minify_js;
+use crate::render::portable::utils::round;
 use crate::render::Renderer;
 use crate::spec::BubblePlot;
 use crate::spec::ColorDefinition;
@@ -13,9 +14,9 @@ use crate::spec::{
     RenderColumnSpec, ScaleType, TickPlot,
 };
 use crate::utils::column_index::ColumnIndex;
-use crate::utils::column_position;
+use crate::utils::column_store::DatasetSummary;
+use crate::utils::column_type::ColumnType;
 use crate::utils::column_type::IsNa;
-use crate::utils::column_type::{classify_table, ColumnType};
 use crate::utils::compress::compress;
 use crate::utils::row_address::RowAddressFactory;
 use anyhow::Result;
@@ -24,7 +25,7 @@ use chrono::{DateTime, Local};
 use itertools::Itertools;
 use serde::Serialize;
 use serde_json::{json, Value};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 use minify_html::{minify, Cfg};
 use std::fs;
@@ -236,6 +237,8 @@ impl Renderer for ItemRenderer {
                         None
                     };
 
+                    let summary = DatasetSummary::build(dataset)?;
+
                     for (page, grouped_records) in &dataset
                         .reader()?
                         .records()?
@@ -265,7 +268,9 @@ impl Renderer for ItemRenderer {
                             &out_path,
                             &headers,
                             dataset,
+                            &summary,
                             table.page_size,
+                            records_length,
                             debug,
                         )?;
                     }
@@ -284,7 +289,7 @@ impl Renderer for ItemRenderer {
                         self.specs.webview_controls,
                         debug,
                         name,
-                        dataset,
+                        &summary,
                         &view_sizes,
                         &self
                             .specs
@@ -304,7 +309,7 @@ impl Renderer for ItemRenderer {
                         table_specs,
                         &table.render_table.as_ref().unwrap().additional_columns,
                     )?;
-                    render_plots(&out_path, dataset, debug)?;
+                    render_plots(&out_path, dataset, &summary, records_length, debug)?;
                 }
             } else {
                 render_empty_dataset(
@@ -443,7 +448,7 @@ fn render_table_javascript<P: AsRef<Path>>(
     webview_controls: bool,
     debug: bool,
     view: &str,
-    dataset: &DatasetSpecs,
+    summary: &DatasetSummary,
     view_sizes: &HashMap<String, String>,
     tables: &[String],
     default_view: &Option<String>,
@@ -470,7 +475,7 @@ fn render_table_javascript<P: AsRef<Path>>(
         webview_host,
         webview_controls,
         header_specs,
-        dataset,
+        summary,
         pages,
         view_sizes,
         tables,
@@ -752,7 +757,7 @@ impl JavascriptConfig {
         webview_host: &str,
         webview_controls: bool,
         header_specs: &Option<HashMap<u32, HeaderSpecs>>,
-        dataset: &DatasetSpecs,
+        summary: &DatasetSummary,
         pages: usize,
         view_sizes: &HashMap<String, String>,
         tables: &[String],
@@ -762,7 +767,6 @@ impl JavascriptConfig {
         report_name: &String,
         title: &String,
     ) -> Self {
-        let column_classification = classify_table(dataset, false).unwrap();
         let header_label_length = if let Some(headers) = header_specs {
             headers.iter().filter(|(_, v)| v.label.is_some()).count()
         } else {
@@ -814,12 +818,11 @@ impl JavascriptConfig {
             available_columns: column_display_mode_filter(&[DisplayMode::Available]),
             pinned_columns: column_display_mode_filter(&[DisplayMode::Pinned]),
             hidden_columns: column_display_mode_filter(&[DisplayMode::Hidden]),
-            displayed_numeric_columns: classify_table(dataset, false)
-                .unwrap()
+            displayed_numeric_columns: summary
+                .headers
                 .iter()
-                .map(|(k, v)| (k.to_owned(), v.is_numeric()))
-                .filter(|(_, v)| *v)
-                .map(|(k, _)| k)
+                .filter(|header| summary.column(header).column_type.is_numeric())
+                .map(|header| header.to_owned())
                 .collect(),
             tick_titles: filter_plot_columns(config, |(_, k)| k.plot.as_ref().unwrap().tick_plot.is_some()),
             bar_titles: filter_plot_columns(config, |(_, k)| k.plot.as_ref().unwrap().bar_plot.is_some()),
@@ -833,10 +836,7 @@ impl JavascriptConfig {
                 .map(|(k, v)| {
                     (
                         k.to_string(),
-                        JavascriptColumnConfig::from_column_spec(
-                            v,
-                            column_classification.get(k).unwrap_or_else(|| panic!("bug: failed to obtain column type for column '{k}'")),
-                        ),
+                        JavascriptColumnConfig::from_column_spec(v, &summary.column(k).column_type),
                     )
                 })
                 .chain(
@@ -857,7 +857,7 @@ impl JavascriptConfig {
                         k.to_string(),
                         render_plot(
                             k,
-                            dataset,
+                            summary,
                             v.plot.as_ref().unwrap().tick_plot.as_ref().unwrap(),
                             v.precision.unwrap(),
                         )
@@ -874,7 +874,7 @@ impl JavascriptConfig {
                         k.to_string(),
                         render_plot(
                             k,
-                            dataset,
+                            summary,
                             v.plot.as_ref().unwrap().bubble_plot.as_ref().unwrap(),
                             v.precision.unwrap(),
                         )
@@ -891,7 +891,7 @@ impl JavascriptConfig {
                         k.to_string(),
                         render_plot(
                             k,
-                            dataset,
+                            summary,
                             v.plot.as_ref().unwrap().bar_plot.as_ref().unwrap(),
                             v.precision.unwrap(),
                         )
@@ -909,7 +909,7 @@ impl JavascriptConfig {
                         v.plot.as_ref().unwrap().heatmap.as_ref().unwrap(),
                         get_column_domain(
                             k,
-                            dataset,
+                            summary,
                             v.plot.as_ref().unwrap().heatmap.as_ref().unwrap(),
                         )
                         .unwrap(),
@@ -937,7 +937,7 @@ impl JavascriptConfig {
                 .chain(
                     config
                         .iter()
-                        .filter(|(title, _)| column_classification.get(&title.to_string()).unwrap().is_numeric())
+                        .filter(|(title, _)| summary.column(title).column_type.is_numeric())
                         .filter_map(|(title, k)| k.plot.as_ref().map(|plot| (title, plot)))
                         .filter_map(|(title, k)| k.heatmap.as_ref().map(|heatmap| (title, heatmap)))
                         .filter(|(_, k)| k.custom_content.is_none())
@@ -1016,7 +1016,11 @@ impl JavascriptConfig {
                 .map(|(k, v)| (k.to_owned(), JavascriptFunction(v.custom.as_ref().unwrap().to_owned()).name()))
                 .collect(),
             additional_colums: additional_columns.as_ref().unwrap_or(&HashMap::new()).iter().map(|(k, v)| (k.to_owned(), JavascriptFunction(v.value.to_string()).name())).collect(),
-            unique_column_values: dataset.unique_column_values().unwrap(),
+            unique_column_values: summary
+                .headers
+                .iter()
+                .map(|header| (header.to_owned(), summary.column(header).unique_count()))
+                .collect(),
             pages,
             view_sizes: view_sizes.to_owned(),
             tables: sorted_tables,
@@ -1359,33 +1363,36 @@ fn render_search_dialogs<P: AsRef<Path>>(
     path: P,
     titles: &[String],
     dataset: &DatasetSpecs,
+    summary: &DatasetSummary,
     page_size: usize,
+    records_length: usize,
     debug: bool,
 ) -> Result<()> {
     let output_path = Path::new(path.as_ref()).join("search");
     fs::create_dir(&output_path)?;
-    let table_classes = classify_table(dataset, false)?;
-    for (column, title) in titles.iter().enumerate() {
-        if table_classes.get(title).unwrap() != &ColumnType::Float {
-            let mut reader = dataset.reader()?;
 
-            let values = reader
-                .records()?
-                .skip(dataset.header_rows - 1)
-                .map(|row| row.get(column).unwrap().to_string())
-                .collect_vec();
+    let mut templates = Tera::default();
+    templates.add_raw_template(
+        "search_dialog.html.tera",
+        include_str!("../../../templates/search_dialog.html.tera"),
+    )?;
 
+    let search_columns: Vec<usize> = titles
+        .iter()
+        .enumerate()
+        .filter(|(_, title)| summary.column(title).column_type != ColumnType::Float)
+        .map(|(column, _)| column)
+        .collect();
+
+    for chunk in search_columns.chunks(column_batch_size(records_length)) {
+        for (offset, values) in read_columns(dataset, chunk)?.into_iter().enumerate() {
+            let column = chunk[offset];
             let compressed_data = compress(json!(values), debug)?;
 
-            let mut templates = Tera::default();
-            templates.add_raw_template(
-                "search_dialog.html.tera",
-                include_str!("../../../templates/search_dialog.html.tera"),
-            )?;
             let mut context = Context::new();
             context.insert("data", &compressed_data);
             context.insert("page_size", &page_size);
-            context.insert("title", &title);
+            context.insert("title", &titles[column]);
 
             let file_path = Path::new(&output_path)
                 .join(Path::new(&format!("column_{column}")).with_extension("html"));
@@ -1526,34 +1533,44 @@ impl PlotConfig for BarPlot {
     }
 }
 
+fn summary_min_max(
+    summary: &DatasetSummary,
+    columns: impl Iterator<Item = String>,
+    precision: Option<u32>,
+) -> (f32, f32) {
+    let mut mins = Vec::new();
+    let mut maxs = Vec::new();
+    for column in columns {
+        let column = summary.column(&column);
+        let (min, max) = match precision {
+            Some(precision) => (round(column.min, precision), round(column.max, precision)),
+            None => (column.min, column.max),
+        };
+        mins.push(min);
+        maxs.push(max);
+    }
+    (
+        mins.into_iter().reduce(f32::min).unwrap(),
+        maxs.into_iter().reduce(f32::max).unwrap(),
+    )
+}
+
 fn render_plot<T: PlotConfig>(
     title: &str,
-    dataset: &DatasetSpecs,
+    summary: &DatasetSummary,
     plot: &T,
     precision: u32,
 ) -> Result<String> {
-    let mut reader = dataset.reader()?;
-    let column_index = reader.headers().map(|s| {
-        s.iter()
-            .position(|t| t == title)
-            .context(ColumnError::NotFound {
-                column: title.to_string(),
-                path: dataset.path.to_str().unwrap().to_string(),
-            })
-            .unwrap()
-    })?;
-
     let (min, max) = if let Some(domain) = plot.domain() {
         (domain[0], domain[1])
     } else if let Some(aux_domain_columns) = plot.aux_domain_columns() {
         let columns = aux_domain_columns
             .iter()
             .map(|s| s.to_string())
-            .chain(std::iter::once(title.to_string()))
-            .collect();
-        get_min_max_multiple_columns(dataset, columns, Some(precision))?
+            .chain(std::iter::once(title.to_string()));
+        summary_min_max(summary, columns, Some(precision))
     } else {
-        get_min_max(dataset, column_index, Some(precision))?
+        summary_min_max(summary, std::iter::once(title.to_string()), Some(precision))
     };
 
     let mut templates = Tera::default();
@@ -1572,86 +1589,34 @@ fn render_plot<T: PlotConfig>(
 
 pub(crate) fn get_column_domain(
     title: &str,
-    dataset: &DatasetSpecs,
+    summary: &DatasetSummary,
     heatmap: &Heatmap,
 ) -> Result<String> {
     if let Some(domain) = &heatmap.domain {
         return Ok(json!(domain).to_string());
     }
 
-    let mut reader = dataset.reader()?;
-
-    let column_index = column_position(title, dataset)?;
-
-    if !heatmap.scale_type.is_quantitative() {
-        if let Some(aux_domain_columns) = &heatmap.aux_domain_columns.0 {
-            let columns = aux_domain_columns
-                .iter()
-                .map(|s| s.to_string())
-                .chain(std::iter::once(title.to_string()))
-                .collect_vec();
-            let column_indexes: HashSet<_> = dataset.reader()?.headers().map(|s| {
-                s.iter()
-                    .enumerate()
-                    .filter(|(_, title)| columns.contains(&title.to_string()))
-                    .map(|(index, _)| index)
-                    .collect()
-            })?;
-            Ok(json!(reader
-                .records()?
-                .skip(dataset.header_rows - 1)
-                .flat_map(|r| r
-                    .iter()
-                    .enumerate()
-                    .filter(|(index, _)| column_indexes.contains(index))
-                    .filter(|(_, value)| !value.as_str().is_na())
-                    .map(|(_, value)| value.to_string())
-                    .collect_vec())
-                .unique()
-                .sorted()
-                .collect_vec())
-            .to_string())
-        } else {
-            Ok(json!(reader
-                .records()?
-                .skip(dataset.header_rows - 1)
-                .map(|r| r.get(column_index).unwrap().to_owned())
-                .filter(|value| !value.as_str().is_na())
-                .unique()
-                .sorted()
-                .collect_vec())
-            .to_string())
-        }
-    } else if let Some(aux_domain_columns) = &heatmap.aux_domain_columns.0 {
-        let columns = aux_domain_columns
+    let columns: Vec<String> = match &heatmap.aux_domain_columns.0 {
+        Some(aux_domain_columns) => aux_domain_columns
             .iter()
-            .map(|s| s.to_string())
+            .map(|column| column.to_string())
             .chain(std::iter::once(title.to_string()))
-            .collect();
-        Ok(json!(get_min_max_multiple_columns(dataset, columns, None)?).to_string())
-    } else {
-        Ok(json!(get_min_max(dataset, column_index, None)?).to_string())
-    }
-}
+            .collect(),
+        None => vec![title.to_string()],
+    };
 
-/// Returns the minimum and maximum for multiple given columns
-fn get_min_max_multiple_columns(
-    dataset: &DatasetSpecs,
-    columns: Vec<String>,
-    precision: Option<u32>,
-) -> Result<(f32, f32)> {
-    let mut mins = Vec::new();
-    let mut maxs = Vec::new();
-    for column in columns {
-        let column_index = column_position(&column, dataset)?;
-        let (min, max) = get_min_max(dataset, column_index, precision)?;
-        mins.push(min);
-        maxs.push(max);
+    if heatmap.scale_type.is_quantitative() {
+        Ok(json!(summary_min_max(summary, columns.into_iter(), None)).to_string())
+    } else {
+        let domain = columns
+            .iter()
+            .flat_map(|column| summary.column(column).value_counts.keys())
+            .filter(|value| !value.as_str().is_na())
+            .unique()
+            .sorted()
+            .collect_vec();
+        Ok(json!(domain).to_string())
     }
-    Ok((
-        mins.into_iter().reduce(f32::min).unwrap(),
-        maxs.into_iter().reduce(f32::max).unwrap(),
-    ))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -2148,12 +2113,6 @@ pub enum TableLinkingError {
 }
 
 #[derive(Error, Debug)]
-pub enum ColumnError {
-    #[error("Could not find column {column:?} in dataset with path {path:?}. If this is intentional try to use optional: true.")]
-    NotFound { column: String, path: String },
-}
-
-#[derive(Error, Debug)]
 pub enum DatasetError {
     #[error("Could not find dataset {dataset_name:?}.")]
     NotFound { dataset_name: String },
@@ -2179,6 +2138,7 @@ pub enum CustomPlotJavascriptFunctionError {
 mod tests {
     use crate::render::portable::{render_plot, JavascriptFunction};
     use crate::spec::{Color, ColorDefinition, ColorRange, DatasetSpecs, ScaleType, TickPlot};
+    use crate::utils::column_store::DatasetSummary;
     use std::path::PathBuf;
 
     #[test]
@@ -2229,7 +2189,8 @@ mod tests {
             links: None,
         };
 
-        let tick_plot = render_plot("price", &dataset, &tick_plot_spec, 2);
+        let summary = DatasetSummary::build(&dataset).unwrap();
+        let tick_plot = render_plot("price", &summary, &tick_plot_spec, 2);
         assert!(tick_plot.is_ok());
         assert!(serde_json::from_str::<serde_json::Value>(&tick_plot.unwrap()).is_ok());
     }
@@ -2261,7 +2222,8 @@ mod tests {
             links: None,
         };
 
-        let tick_plot = render_plot("price", &dataset, &tick_plot_spec, 2);
+        let summary = DatasetSummary::build(&dataset).unwrap();
+        let tick_plot = render_plot("price", &summary, &tick_plot_spec, 2);
         assert!(tick_plot.is_ok());
         assert!(serde_json::from_str::<serde_json::Value>(&tick_plot.unwrap()).is_ok());
     }
@@ -2283,7 +2245,8 @@ mod tests {
             links: None,
         };
 
-        let bar_plot = render_plot("price", &dataset, &bar_plot_spec, 2);
+        let summary = DatasetSummary::build(&dataset).unwrap();
+        let bar_plot = render_plot("price", &summary, &bar_plot_spec, 2);
         assert!(bar_plot.is_ok());
         assert!(serde_json::from_str::<serde_json::Value>(&bar_plot.unwrap()).is_ok());
     }
@@ -2315,7 +2278,8 @@ mod tests {
             links: None,
         };
 
-        let bar_plot = render_plot("price", &dataset, &bar_plot_spec, 2);
+        let summary = DatasetSummary::build(&dataset).unwrap();
+        let bar_plot = render_plot("price", &summary, &bar_plot_spec, 2);
         assert!(bar_plot.is_ok());
         assert!(serde_json::from_str::<serde_json::Value>(&bar_plot.unwrap()).is_ok());
     }

--- a/src/render/portable/plot.rs
+++ b/src/render/portable/plot.rs
@@ -1,7 +1,7 @@
-use crate::render::portable::utils::{minify_js, round};
+use crate::render::portable::utils::minify_js;
 use crate::spec::DatasetSpecs;
+use crate::utils::column_store::DatasetSummary;
 use crate::utils::column_type::IsNa;
-use crate::utils::column_type::{classify_table, ColumnType};
 use anyhow::Result;
 use itertools::Itertools;
 use serde::Serialize;
@@ -17,40 +17,46 @@ use tera::{Context, Tera};
 pub(crate) fn render_plots<P: AsRef<Path>>(
     output_path: P,
     dataset: &DatasetSpecs,
+    summary: &DatasetSummary,
+    records_length: usize,
     debug: bool,
 ) -> Result<()> {
-    let column_types = classify_table(dataset, true)?;
-
-    let mut reader = dataset.reader()?;
-
     let path = Path::new(output_path.as_ref()).join("plots");
     fs::create_dir(&path)?;
-    let mut plots = Vec::new();
 
-    for (index, column) in reader.headers()?.iter().enumerate() {
+    let numeric_indices: Vec<usize> = (0..summary.headers.len())
+        .filter(|index| summary.column_at(*index).column_type.is_numeric())
+        .collect();
+    let mut numeric_plots: HashMap<usize, Option<Vec<BinnedPlotRecord>>> = HashMap::new();
+    for chunk in numeric_indices.chunks(column_batch_size(records_length)) {
+        for (offset, values) in read_columns(dataset, chunk)?.into_iter().enumerate() {
+            numeric_plots.insert(chunk[offset], generate_numeric_plot(&values));
+        }
+    }
+
+    let mut plots = Vec::new();
+    for (index, column) in summary.headers.iter().enumerate() {
         let mut templates = Tera::default();
         let mut context = Context::new();
         context.insert("title", &column);
         context.insert("index", &index);
-        match column_types.get(column) {
-            None => unreachable!(),
-            Some(ColumnType::String) | Some(ColumnType::None) => {
-                let plot = generate_nominal_plot(dataset, index)?;
-                templates.add_raw_template(
-                    "plot.js.tera",
-                    include_str!("../../../templates/nominal_plot.js.tera"),
-                )?;
-                context.insert("table", &json!(plot).to_string())
-            }
-            Some(ColumnType::Integer) | Some(ColumnType::Float) => {
-                let plot = generate_numeric_plot(dataset, index)?;
-                templates.add_raw_template(
-                    "plot.js.tera",
-                    include_str!("../../../templates/numeric_plot.js.tera"),
-                )?;
-                context.insert("table", &json!(plot).to_string())
-            }
-        };
+        if summary.column_at(index).column_type.is_numeric() {
+            templates.add_raw_template(
+                "plot.js.tera",
+                include_str!("../../../templates/numeric_plot.js.tera"),
+            )?;
+            context.insert(
+                "table",
+                &json!(numeric_plots.remove(&index).unwrap()).to_string(),
+            );
+        } else {
+            let plot = generate_nominal_plot(&summary.column_at(index).value_counts);
+            templates.add_raw_template(
+                "plot.js.tera",
+                include_str!("../../../templates/nominal_plot.js.tera"),
+            )?;
+            context.insert("table", &json!(plot).to_string());
+        }
         let js = templates.render("plot.js.tera", &context)?;
         plots.push(js);
     }
@@ -60,6 +66,22 @@ pub(crate) fn render_plots<P: AsRef<Path>>(
     let minified = minify_js(&js_plots, debug)?;
     file.write_all(&minified)?;
     Ok(())
+}
+
+const COLUMN_BUFFER_CELLS: usize = 4_000_000;
+
+pub(crate) fn column_batch_size(records_length: usize) -> usize {
+    (COLUMN_BUFFER_CELLS / records_length.max(1)).max(1)
+}
+
+pub(crate) fn read_columns(dataset: &DatasetSpecs, columns: &[usize]) -> Result<Vec<Vec<String>>> {
+    let mut buffers: Vec<Vec<String>> = columns.iter().map(|_| Vec::new()).collect();
+    for record in dataset.reader()?.records()?.skip(dataset.header_rows - 1) {
+        for (buffer, &column) in buffers.iter_mut().zip(columns) {
+            buffer.push(record.get(column).unwrap().to_string());
+        }
+    }
+    Ok(buffers)
 }
 
 fn binned_counts(values: &[f32], min: f32, max: f32, num_bins: usize) -> Vec<u32> {
@@ -118,21 +140,15 @@ fn refined_bins(values: &[f32], min: f32, max: f32) -> Vec<BinnedPlotRecord> {
     counts_to_records(&counts, min, max)
 }
 
-fn generate_numeric_plot(
-    dataset: &DatasetSpecs,
-    column_index: usize,
-) -> Result<Option<Vec<BinnedPlotRecord>>> {
-    let mut reader = dataset.reader()?;
-
-    let mut values = Vec::new();
+fn generate_numeric_plot(values: &[String]) -> Option<Vec<BinnedPlotRecord>> {
+    let mut numbers = Vec::new();
     let mut nan = 0u32;
     let mut min = f32::INFINITY;
     let mut max = f32::NEG_INFINITY;
 
-    for record in reader.records()?.skip(dataset.header_rows - 1) {
-        let value = record.get(column_index).unwrap();
+    for value in values {
         if let Ok(number) = f32::from_str(value) {
-            values.push(number);
+            numbers.push(number);
             min = min.min(number);
             max = max.max(number);
         } else {
@@ -141,10 +157,10 @@ fn generate_numeric_plot(
     }
 
     if min == max {
-        return Ok(None);
+        return None;
     }
 
-    let mut result = refined_bins(&values, min, max);
+    let mut result = refined_bins(&numbers, min, max);
 
     if nan > 0 {
         result.push(BinnedPlotRecord {
@@ -154,64 +170,32 @@ fn generate_numeric_plot(
         });
     }
 
-    Ok(Some(result))
-}
-
-/// Finds the numeric minimum and maximum value of a csv column
-pub(crate) fn get_min_max(
-    dataset: &DatasetSpecs,
-    column_index: usize,
-    precision: Option<u32>,
-) -> Result<(f32, f32)> {
-    let mut reader = dataset.reader()?;
-
-    let (min, max) = reader
-        .records()?
-        .skip(dataset.header_rows - 1)
-        .map(|r| r.get(column_index).unwrap().to_string())
-        .filter_map(|s| s.parse::<f32>().ok())
-        .fold((f32::INFINITY, f32::NEG_INFINITY), |(min, max), v| {
-            (min.min(v), max.max(v))
-        });
-
-    if let Some(p) = precision {
-        Ok((round(min, p), round(max, p)))
-    } else {
-        Ok((min, max))
-    }
+    Some(result)
 }
 
 /// Generates plot records for columns of type String
-fn generate_nominal_plot(
-    dataset: &DatasetSpecs,
-    column_index: usize,
-) -> Result<Option<Vec<PlotRecord>>> {
-    let mut reader = dataset.reader()?;
-
-    let mut count_values = HashMap::new();
-
-    for result in reader.records()?.skip(dataset.header_rows - 1) {
-        let value = result.get(column_index).unwrap();
-        if !value.as_str().is_na() {
-            let entry = count_values.entry(value.to_owned()).or_insert_with(|| 0);
-            *entry += 1;
+fn generate_nominal_plot(value_counts: &HashMap<String, usize>) -> Option<Vec<PlotRecord>> {
+    let mut counts: HashMap<&str, u32> = HashMap::new();
+    for (value, count) in value_counts {
+        let key = if value.as_str().is_na() {
+            "NA"
         } else {
-            let entry = count_values.entry("NA".to_owned()).or_insert_with(|| 0);
-            *entry += 1;
-        }
+            value.as_str()
+        };
+        *counts.entry(key).or_insert(0) += *count as u32;
     }
 
-    let mut plot_data = count_values
+    let mut plot_data = counts
         .iter()
-        .map(|(k, v)| PlotRecord {
-            key: k.to_string(),
-            value: *v,
+        .map(|(key, value)| PlotRecord {
+            key: key.to_string(),
+            value: *value,
         })
         .collect_vec();
 
-    let unique_values = count_values.values().unique().count();
+    let unique_values = counts.values().unique().count();
     if unique_values <= 1 {
-        return Ok(None);
+        return None;
     };
 
     if plot_data.len() > MAX_NOMINAL_BINS {
@@ -219,7 +203,7 @@ fn generate_nominal_plot(
         plot_data = plot_data.into_iter().take(MAX_NOMINAL_BINS).collect();
     }
 
-    Ok(Some(plot_data))
+    Some(plot_data)
 }
 
 const MAX_NOMINAL_BINS: usize = 10;
@@ -243,6 +227,7 @@ struct BinnedPlotRecord {
 mod tests {
     use crate::render::portable::plot::{generate_nominal_plot, PlotRecord};
     use crate::spec::DatasetSpecs;
+    use crate::utils::column_store::DatasetSummary;
     use std::str::FromStr;
 
     #[test]
@@ -257,7 +242,8 @@ mod tests {
             links: None,
             offer_excel: false,
         };
-        let mut records = generate_nominal_plot(&dataset, 0).unwrap().unwrap();
+        let summary = DatasetSummary::build(&dataset).unwrap();
+        let mut records = generate_nominal_plot(&summary.column_at(0).value_counts).unwrap();
         records.sort_unstable();
         let mut expected = vec![
             PlotRecord {

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -8,6 +8,7 @@ use crate::spec::ConfigError::{
     WrongDomainLengthWithMidDomain, WrongRangeLengthWithMidDomain,
 };
 use crate::utils::column_position;
+use crate::utils::column_store::DatasetSummary;
 use crate::utils::column_type::{classify_table, ColumnType};
 use anyhow::{anyhow, Result};
 use anyhow::{bail, Context};
@@ -563,32 +564,6 @@ impl DatasetSpecs {
             _ => Ok(','),
         }
     }
-
-    /// Returns a hashmap counting the number of unique values of all columns of the dataset
-    pub fn unique_column_values(&self) -> Result<HashMap<String, usize>> {
-        let mut reader = self.reader()?;
-        let headers = reader.headers()?.clone();
-        let column_counts: HashMap<String, usize> = headers
-            .iter()
-            .enumerate()
-            .map(|(index, column)| {
-                let mut reader = self.reader().unwrap();
-                (
-                    column.to_string(),
-                    reader
-                        .records()
-                        .unwrap()
-                        .skip(self.header_rows - 1)
-                        .map(|row| row.get(index).unwrap().to_string())
-                        .unique()
-                        .collect_vec()
-                        .len(),
-                )
-            })
-            .collect();
-
-        Ok(column_counts)
-    }
 }
 
 #[skip_serializing_none]
@@ -801,9 +776,22 @@ impl ItemSpecs {
             }
         }
         if self.render_table.is_some() {
+            let needs_summary = indexed_keys.iter().any(|(title, spec)| {
+                headers.contains(title)
+                    && spec
+                        .plot
+                        .as_ref()
+                        .and_then(|plot| plot.heatmap.as_ref())
+                        .is_some_and(|heatmap| heatmap.domain.is_none())
+            });
+            let summary = if needs_summary {
+                Some(DatasetSummary::build(dataset)?)
+            } else {
+                None
+            };
             for (title, render_column_specs) in indexed_keys.iter_mut() {
                 if headers.contains(title) {
-                    render_column_specs.preprocess(dataset, title)?;
+                    render_column_specs.preprocess(dataset, summary.as_ref(), title)?;
                 }
             }
         }
@@ -1002,13 +990,18 @@ pub enum HeaderDisplayMode {
 }
 
 impl RenderColumnSpec {
-    fn preprocess(&mut self, dataset: &DatasetSpecs, title: &str) -> Result<()> {
+    fn preprocess(
+        &mut self,
+        dataset: &DatasetSpecs,
+        summary: Option<&DatasetSummary>,
+        title: &str,
+    ) -> Result<()> {
         if !dataset.is_empty()? {
             if let Some(plot) = &mut self.plot {
                 if let Some(ticks) = &mut plot.tick_plot {
                     ticks.preprocess(dataset)?;
                 } else if let Some(heatmap) = &mut plot.heatmap {
-                    heatmap.preprocess(dataset, title)?;
+                    heatmap.preprocess(dataset, summary, title)?;
                 } else if let Some(bars) = &mut plot.bar_plot {
                     bars.preprocess(dataset)?;
                 } else if let Some(pills) = &mut plot.pills {
@@ -1038,7 +1031,12 @@ impl TickPlot {
 }
 
 impl Heatmap {
-    fn preprocess(&mut self, dataset: &DatasetSpecs, title: &str) -> Result<()> {
+    fn preprocess(
+        &mut self,
+        dataset: &DatasetSpecs,
+        summary: Option<&DatasetSummary>,
+        title: &str,
+    ) -> Result<()> {
         self.aux_domain_columns.preprocess(dataset)?;
         self.scale_type.preprocess();
         match self.vega_type {
@@ -1058,7 +1056,7 @@ impl Heatmap {
             })
         }
         if self.domain.is_none() {
-            let d = get_column_domain(title, dataset, self)?;
+            let d = get_column_domain(title, summary.unwrap(), self)?;
             let domain: Vec<String> = if self.scale_type.is_quantitative() {
                 let floating_domain: Vec<f64> = serde_json::from_str(&d).map_err(|_| {
                     ConfigError::NonNumericQuantitativeColumn {
@@ -2619,34 +2617,6 @@ mod tests {
         };
         empty_dataset.preprocess().unwrap();
         assert!(empty_dataset.is_empty().unwrap());
-    }
-
-    #[test]
-    fn test_dataset_unique_column_values() {
-        let config = ItemsSpec::from_file(".examples/example-config.yaml").unwrap();
-        let unique_column_values = config
-            .datasets
-            .get("oscars")
-            .unwrap()
-            .unique_column_values()
-            .unwrap();
-        assert_eq!(unique_column_values.get("oscar_yr").unwrap(), &91_usize);
-        assert_eq!(unique_column_values.get("award").unwrap(), &2_usize);
-    }
-
-    #[test]
-    fn test_unique_column_values_skips_additional_header_rows() {
-        let mut dataset = DatasetSpecs {
-            path: PathBuf::from("tests/data/additional_header_rows.csv"),
-            separator: char::default(),
-            header_rows: 2,
-            links: None,
-            offer_excel: false,
-        };
-        dataset.preprocess().unwrap();
-        let unique_column_values = dataset.unique_column_values().unwrap();
-        assert_eq!(unique_column_values.get("sample").unwrap(), &2_usize);
-        assert_eq!(unique_column_values.get("value").unwrap(), &3_usize);
     }
 
     #[test]

--- a/src/utils/column_store.rs
+++ b/src/utils/column_store.rs
@@ -1,0 +1,133 @@
+use crate::spec::DatasetSpecs;
+use crate::utils::column_type::ColumnType;
+use anyhow::Result;
+use std::collections::HashMap;
+
+pub(crate) struct ColumnSummary {
+    pub(crate) column_type: ColumnType,
+    pub(crate) min: f32,
+    pub(crate) max: f32,
+    pub(crate) value_counts: HashMap<String, usize>,
+}
+
+impl ColumnSummary {
+    pub(crate) fn unique_count(&self) -> usize {
+        self.value_counts.len()
+    }
+}
+
+pub(crate) struct DatasetSummary {
+    pub(crate) headers: Vec<String>,
+    columns: Vec<ColumnSummary>,
+    positions: HashMap<String, usize>,
+}
+
+impl DatasetSummary {
+    pub(crate) fn build(dataset: &DatasetSpecs) -> Result<Self> {
+        let headers = dataset.reader()?.headers()?.clone();
+        let mut columns: Vec<ColumnSummary> = headers
+            .iter()
+            .map(|_| ColumnSummary {
+                column_type: ColumnType::default(),
+                min: f32::INFINITY,
+                max: f32::NEG_INFINITY,
+                value_counts: HashMap::new(),
+            })
+            .collect();
+        for record in dataset.reader()?.records()?.skip(dataset.header_rows - 1) {
+            for (summary, (title, value)) in
+                columns.iter_mut().zip(headers.iter().zip(record.iter()))
+            {
+                summary.column_type.update(value, title, true)?;
+                if let Ok(number) = value.parse::<f32>() {
+                    summary.min = summary.min.min(number);
+                    summary.max = summary.max.max(number);
+                }
+                *summary.value_counts.entry(value.to_string()).or_insert(0) += 1;
+            }
+        }
+        let positions = headers
+            .iter()
+            .enumerate()
+            .map(|(index, header)| (header.clone(), index))
+            .collect();
+        Ok(Self {
+            headers,
+            columns,
+            positions,
+        })
+    }
+
+    pub(crate) fn column(&self, title: &str) -> &ColumnSummary {
+        &self.columns[self.positions[title]]
+    }
+
+    pub(crate) fn column_at(&self, index: usize) -> &ColumnSummary {
+        &self.columns[index]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DatasetSummary;
+    use crate::spec::DatasetSpecs;
+    use crate::utils::column_type::classify_table;
+    use std::collections::HashSet;
+    use std::str::FromStr;
+
+    fn dataset(path: &str, header_rows: usize) -> DatasetSpecs {
+        DatasetSpecs {
+            path: path.to_string().parse().unwrap(),
+            separator: char::from_str(",").unwrap(),
+            header_rows,
+            links: None,
+            offer_excel: false,
+        }
+    }
+
+    fn min_max(dataset: &DatasetSpecs, index: usize) -> (f32, f32) {
+        dataset
+            .reader()
+            .unwrap()
+            .records()
+            .unwrap()
+            .skip(dataset.header_rows - 1)
+            .filter_map(|record| record.get(index).unwrap().parse::<f32>().ok())
+            .fold((f32::INFINITY, f32::NEG_INFINITY), |(min, max), value| {
+                (min.min(value), max.max(value))
+            })
+    }
+
+    fn unique_count(dataset: &DatasetSpecs, index: usize) -> usize {
+        dataset
+            .reader()
+            .unwrap()
+            .records()
+            .unwrap()
+            .skip(dataset.header_rows - 1)
+            .map(|record| record.get(index).unwrap().to_string())
+            .collect::<HashSet<_>>()
+            .len()
+    }
+
+    #[test]
+    fn test_summary_matches_standalone_functions() {
+        for (path, header_rows) in [
+            ("tests/data/uniform_datatypes.csv", 1),
+            ("tests/data/non_uniform_datatypes.csv", 1),
+            ("tests/data/empty_table.csv", 1),
+            ("tests/data/additional_header_rows.csv", 2),
+        ] {
+            let dataset = dataset(path, header_rows);
+            let summary = DatasetSummary::build(&dataset).unwrap();
+            let classification = classify_table(&dataset, false).unwrap();
+
+            for (index, header) in summary.headers.iter().enumerate() {
+                let column = summary.column_at(index);
+                assert_eq!(&column.column_type, classification.get(header).unwrap());
+                assert_eq!(column.unique_count(), unique_count(&dataset, index));
+                assert_eq!((column.min, column.max), min_max(&dataset, index));
+            }
+        }
+    }
+}

--- a/src/utils/column_type.rs
+++ b/src/utils/column_type.rs
@@ -15,7 +15,7 @@ pub enum ColumnType {
 }
 
 impl ColumnType {
-    fn update(&mut self, value: &str, column: &str, warn: bool) -> Result<bool> {
+    pub(crate) fn update(&mut self, value: &str, column: &str, warn: bool) -> Result<bool> {
         let mut float_warning = warn;
         if !value.is_na() {
             *self = match (

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -2,6 +2,7 @@ use crate::spec::DatasetSpecs;
 use anyhow::Result;
 
 pub(crate) mod column_index;
+pub(crate) mod column_store;
 pub mod column_type;
 pub(crate) mod compress;
 pub(crate) mod row_address;


### PR DESCRIPTION
Introduces `DatasetSummary`, one streaming pass per dataset yielding each column's type, numeric min/max and value counts. Column classification, unique value counts, overview plots, heatmap domains, plot ranges and search dialogs now read from it instead of re-reading the whole dataset once per column, replacing the previous O(columns²) re-parsing with a single O(columns) pass; numeric histograms and search dialogs read their raw values in cell-budgeted batches.