### PR TITLE
docs: Add citation metadata

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,49 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite the article below."
+title: "Datavzrd: Rapid programming- and maintenance-free interactive visualization and communication of tabular data"
+authors:
+  - family-names: Wiegand
+    given-names: Felix
+  - family-names: Lähnemann
+    given-names: David
+  - family-names: Mölder
+    given-names: Felix
+  - family-names: Uzuner
+    given-names: Hamdiye
+  - family-names: Prinz
+    given-names: Adrian
+  - family-names: Schramm
+    given-names: Alexander
+  - family-names: Köster
+    given-names: Johannes
+repository-code: "https://github.com/datavzrd/datavzrd"
+url: "https://datavzrd.github.io/"
+license: MIT
+preferred-citation:
+  type: article
+  title: "Datavzrd: Rapid programming- and maintenance-free interactive visualization and communication of tabular data"
+  authors:
+    - family-names: Wiegand
+      given-names: Felix
+    - family-names: Lähnemann
+      given-names: David
+    - family-names: Mölder
+      given-names: Felix
+    - family-names: Uzuner
+      given-names: Hamdiye
+    - family-names: Prinz
+      given-names: Adrian
+    - family-names: Schramm
+      given-names: Alexander
+    - family-names: Köster
+      given-names: Johannes
+  journal: "PLOS ONE"
+  publisher:
+    name: "Public Library of Science"
+  year: 2025
+  month: 7
+  volume: 20
+  issue: 7
+  start: e0323079
+  doi: 10.1371/journal.pone.0323079
+  url: "https://doi.org/10.1371/journal.pone.0323079"

--- a/README.md
+++ b/README.md
@@ -14,6 +14,31 @@ Documentation is available via the official website: https://datavzrd.github.io/
 
 An example report can be [viewed online](https://datavzrd.github.io/datavzrd/index.html) with the [corresponding config file](https://github.com/datavzrd/datavzrd/tree/main/.examples/example-config.yaml).
 
+## Citation
+
+If you use datavzrd in your research, please cite:
+
+> Wiegand F, Lähnemann D, Mölder F, Uzuner H, Prinz A, Schramm A, Köster J. Datavzrd: Rapid programming- and maintenance-free interactive visualization and communication of tabular data. PLOS ONE. 2025;20(7):e0323079. https://doi.org/10.1371/journal.pone.0323079
+
+<details>
+<summary>BibTeX</summary>
+
+```bibtex
+@article{wiegand2025datavzrd,
+  title     = {Datavzrd: Rapid programming- and maintenance-free interactive visualization and communication of tabular data},
+  author    = {Wiegand, Felix and L{\"a}hnemann, David and M{\"o}lder, Felix and Uzuner, Hamdiye and Prinz, Adrian and Schramm, Alexander and K{\"o}ster, Johannes},
+  journal   = {PLOS ONE},
+  volume    = {20},
+  number    = {7},
+  pages     = {e0323079},
+  year      = {2025},
+  doi       = {10.1371/journal.pone.0323079},
+  publisher = {Public Library of Science}
+}
+```
+
+</details>
+
 ## Contributing
 
 Contributions of any kind are welcome! For more info check the [contributing guide](https://datavzrd.github.io/docs/contributing.html).


### PR DESCRIPTION
Adds a CITATION.cff pointing at the PLOS ONE paper and a short citation section with BibTeX to the README.