### PR TITLE
feat: Allow link-to-url on pills and heatmap columns

### DIFF
--- a/.examples/example-config.yaml
+++ b/.examples/example-config.yaml
@@ -95,7 +95,9 @@ views:
             pills:
               separator: ","
               color-scheme: category20
-              ellipsis: 5
+          link-to-url:
+            IMDb genre:
+              url: "https://www.imdb.com/search/title/?genres={pill-value}"
         imdbID:
           link-to-url:
             IMDB:
@@ -128,6 +130,9 @@ views:
               color-scheme: tableau20
               legend:
                 title: Rating
+          link-to-url:
+            Rating info:
+              url: "https://www.google.com/search?q={value}+film+rating"
         Runtime:
           custom-path: ".examples/specs/time-formatter.js"
   movies-plot:

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -200,11 +200,13 @@ impl ItemsSpec {
                                     possible_conflicting.push("ticks".to_string());
                                 }
                             }
-                            if possible_conflicting.len() > 1
-                                && !(possible_conflicting.contains(&"heatmap".to_string())
-                                    && possible_conflicting.contains(&"ellipsis".to_string())
-                                    && possible_conflicting.len() == 2)
-                            {
+                            let has = |feature: &str| {
+                                possible_conflicting.iter().any(|c| c == feature)
+                            };
+                            let allowed_pairing = possible_conflicting.len() == 2
+                                && has("heatmap")
+                                && (has("ellipsis") || has("link-to-url"));
+                            if possible_conflicting.len() > 1 && !allowed_pairing {
                                 bail!(ConflictingConfiguration {
                                     view: name.to_string(),
                                     column: column.to_string(),
@@ -2350,6 +2352,54 @@ mod tests {
             "#;
         let config: ItemsSpec = serde_yaml::from_str(raw_config).unwrap();
         assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn test_heatmap_with_link_to_url_config_validation() {
+        let raw_config = r#"
+            datasets:
+                table-a:
+                    path: tests/data/uniform_datatypes.csv
+                    separator: ","
+            views:
+                table-a:
+                    dataset: table-a
+                    render-table:
+                        columns:
+                            first:
+                                plot:
+                                    heatmap:
+                                        scale: ordinal
+                                        color-scheme: tableau20
+                                link-to-url:
+                                    example:
+                                        url: "https://example.com/{value}"
+            "#;
+        let config: ItemsSpec = serde_yaml::from_str(raw_config).unwrap();
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_heatmap_with_ellipsis_config_validation() {
+        let raw_config = r#"
+            datasets:
+                table-a:
+                    path: tests/data/uniform_datatypes.csv
+                    separator: ","
+            views:
+                table-a:
+                    dataset: table-a
+                    render-table:
+                        columns:
+                            first:
+                                plot:
+                                    heatmap:
+                                        scale: ordinal
+                                        color-scheme: tableau20
+                                ellipsis: 5
+            "#;
+        let config: ItemsSpec = serde_yaml::from_str(raw_config).unwrap();
+        assert!(config.validate().is_ok());
     }
 
     #[test]

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -200,9 +200,8 @@ impl ItemsSpec {
                                     possible_conflicting.push("ticks".to_string());
                                 }
                             }
-                            let has = |feature: &str| {
-                                possible_conflicting.iter().any(|c| c == feature)
-                            };
+                            let has =
+                                |feature: &str| possible_conflicting.iter().any(|c| c == feature);
                             let allowed_pairing = possible_conflicting.len() == 2
                                 && has("heatmap")
                                 && (has("ellipsis") || has("link-to-url"));

--- a/web/src/datavzrd.js
+++ b/web/src/datavzrd.js
@@ -147,6 +147,16 @@ function addNumClass(dp_num, ah, detail_mode, config) {
   }
 }
 
+function findLink(title) {
+  return config.link_urls.find((l) => l.title === title);
+}
+
+function isAlreadyRenderedByPlot(title) {
+  return (
+    config.pill_titles.includes(title) || config.heatmap_titles.includes(title)
+  );
+}
+
 function detailFormatter(index, row) {
   let cp = config.custom_plot_titles;
   let ticks = config.tick_titles;
@@ -169,12 +179,13 @@ function detailFormatter(index, row) {
       if (config.column_config[key].label) {
         card_title = config.column_config[key].label;
       }
+      let isLink = link_urls.includes(key) && !isAlreadyRenderedByPlot(key);
       if (
         cp.includes(key) ||
         ticks.includes(key) ||
         bars.includes(key) ||
         bubbles.includes(key) ||
-        link_urls.includes(key)
+        isLink
       ) {
         if (cp.includes(key)) {
           id = `detail-plot-${index}-cp-${config.columns.indexOf(key)}`;
@@ -182,7 +193,7 @@ function detailFormatter(index, row) {
           id = `detail-plot-${index}-bars-${config.columns.indexOf(key)}`;
         } else if (bubbles.includes(key)) {
           id = `detail-plot-${index}-bubbles-${config.columns.indexOf(key)}`;
-        } else if (link_urls.includes(key)) {
+        } else if (isLink) {
           id = `detail-plot-${index}-links-${config.columns.indexOf(key)}`;
         } else {
           id = `detail-plot-${index}-ticks-${config.columns.indexOf(key)}`;
@@ -191,7 +202,7 @@ function detailFormatter(index, row) {
                    <div class="card-header">
                      ${card_title}
                    </div>
-                   <div class="card-body">
+                   <div class="card-body${isLink ? " centered-card" : ""}">
                      <div id="${id}"></div>
                    </div>
                  </div>`;
@@ -202,7 +213,7 @@ function detailFormatter(index, row) {
                   <div class="card-header">
                     ${card_title}
                   </div>
-                  <div id="${id}" class="card-body">
+                  <div id="${id}" class="card-body centered-card">
                     ${value}
                   </div>
                 </div>`;
@@ -213,7 +224,7 @@ function detailFormatter(index, row) {
                   <div class="card-header">
                     ${card_title}
                   </div>
-                  <div id="${id}" class="card-body">
+                  <div id="${id}" class="card-body centered-card">
                     ${value}
                   </div>
                 </div>`;
@@ -289,7 +300,7 @@ function render(
   }
 
   for (const o of config.link_urls) {
-    if (displayed_columns.includes(o.title)) {
+    if (displayed_columns.includes(o.title) && !isAlreadyRenderedByPlot(o.title)) {
       linkUrlColumn(
         columns,
         o.title,
@@ -309,6 +320,8 @@ function render(
         config.detail_mode,
         config.header_label_length,
         columnIndexMap,
+        findLink(o.title),
+        columns,
       );
     }
   }
@@ -322,6 +335,8 @@ function render(
         config.detail_mode,
         config.header_label_length,
         columnIndexMap,
+        findLink(o.title),
+        columns,
       );
     }
   }
@@ -740,7 +755,7 @@ export function load() {
 
     $("#table").on("expand-row.bs.table", (event, index, row, detailView) => {
       for (const o of config.link_urls) {
-        if (!config.displayed_columns.includes(o.title)) {
+        if (!config.displayed_columns.includes(o.title) && !isAlreadyRenderedByPlot(o.title)) {
           linkDetailUrlColumn(
             row,
             `#detail-plot-${index}-links-${columnIdMap[o.title]}`,
@@ -773,6 +788,8 @@ export function load() {
             row,
             config.column_config[o.title].is_float,
             config.column_config[o.title].precision,
+            findLink(o.title),
+            config.columns,
           );
         }
       }
@@ -783,6 +800,9 @@ export function load() {
             row[o.title],
             `#pills-${index}-${columnIdMap[o.title]}`,
             o,
+            findLink(o.title),
+            config.columns,
+            row,
           );
         }
       }

--- a/web/src/description.js
+++ b/web/src/description.js
@@ -23,7 +23,7 @@ export function renderMarkdownDescription(is_plot_view) {
     );
   }
   if (!is_plot_view) {
-    var heatmaps = config.heatmaps;
+    var heatmaps = [...config.heatmaps];
     if (header_config.heatmaps) {
       for (const e of header_config.heatmaps) {
         var domain = (domain = [

--- a/web/src/plot/heatmap.js
+++ b/web/src/plot/heatmap.js
@@ -2,6 +2,7 @@ import $ from "jquery";
 import * as vega from "vega";
 import * as d3 from "d3";
 import { precision_formatter } from "../utils";
+import { createLinkHtml } from "./link-to-url";
 
 export function colorizeColumn(
   ah,
@@ -10,6 +11,8 @@ export function colorizeColumn(
   detail_mode,
   header_label_length,
   columnIndexMap,
+  link,
+  link_columns,
 ) {
   let index = columnIndexMap[heatmap.title];
   let row = 0;
@@ -29,10 +32,23 @@ export function colorizeColumn(
         this.style.setProperty("color", "white", "important");
       }
     }
+    let shown_value = value;
     if (custom_func) {
       var data_function = window[custom_func];
-      value = data_function(value, table_rows[row]);
-      this.innerHTML = value;
+      shown_value = data_function(value, table_rows[row]);
+      this.innerHTML = shown_value;
+    } else {
+      shown_value = this.innerHTML;
+    }
+    if (link && value !== "") {
+      this.classList.add("linked-cell");
+      this.innerHTML = createLinkHtml(
+        link_columns,
+        link.links,
+        value,
+        shown_value,
+        table_rows[row],
+      );
     }
     row++;
   });
@@ -87,7 +103,16 @@ export function datavzrdScale(heatmap) {
   return scale;
 }
 
-export function colorizeDetailCard(value, div, heatmap, row, is_float, precision) {
+export function colorizeDetailCard(
+  value,
+  div,
+  heatmap,
+  row,
+  is_float,
+  precision,
+  link,
+  link_columns,
+) {
   let scale = datavzrdScale(heatmap);
 
   if (value !== "") {
@@ -99,13 +124,24 @@ export function colorizeDetailCard(value, div, heatmap, row, is_float, precision
       }
     }
   }
+  let shown_value = value;
   if (heatmap.heatmap["custom-content"]) {
     var data_function = window[heatmap.heatmap["custom-content"]];
-    value = data_function(value, row);
-    $(`${div}`)[0].innerHTML = value;
+    shown_value = data_function(value, row);
+    $(`${div}`)[0].innerHTML = shown_value;
   } else if (is_float && precision !== undefined) {
-    value = precision_formatter(precision, value);
-    $(`${div}`)[0].innerHTML = value;
+    shown_value = precision_formatter(precision, value);
+    $(`${div}`)[0].innerHTML = shown_value;
+  }
+  if (link && value !== "") {
+    $(`${div}`).addClass("linked-cell");
+    $(`${div}`)[0].innerHTML = createLinkHtml(
+      link_columns,
+      link.links,
+      value,
+      shown_value,
+      row,
+    );
   }
 }
 

--- a/web/src/plot/link-to-url.js
+++ b/web/src/plot/link-to-url.js
@@ -1,29 +1,45 @@
 import $ from "jquery";
 
-export function createLinkHtml(columns, link_urls, value, shown_value, row) {
-  if (link_urls.length == 1) {
-    let link = link_urls[0].link.url.replaceAll("{value}", value);
-    for (const column of columns) {
-      link = link.replaceAll(`{${column}}`, row[column]);
+function buildLinkUrl(url, columns, value, row, pill_value) {
+  let link = url.replaceAll("{value}", value);
+  if (pill_value !== undefined) {
+    link = link.replaceAll("{pill-value}", pill_value);
+  }
+  for (const column of columns) {
+    link = link.replaceAll(`{${column}}`, row[column]);
+  }
+  return link;
+}
+
+export function dropdownItems(columns, link_urls, value, row, pill_value) {
+  let items = "";
+  for (let l of link_urls) {
+    let link = buildLinkUrl(l.link.url, columns, value, row, pill_value);
+    if (l.link["new-window"]) {
+      items = `${items}<a class="dropdown-item" href="${link}" target='_blank' rel="noopener noreferrer" >${l.name}</a>`;
+    } else {
+      items = `${items}<a class="dropdown-item" href="${link}" >${l.name}</a>`;
     }
+  }
+  return items;
+}
+
+export function createLinkHtml(
+  columns,
+  link_urls,
+  value,
+  shown_value,
+  row,
+  pill_value,
+) {
+  if (link_urls.length == 1) {
+    let link = buildLinkUrl(link_urls[0].link.url, columns, value, row, pill_value);
     if (link_urls[0].link["new-window"]) {
       return `<a href="${link}" target="_blank" rel="noopener noreferrer" >${shown_value}</a>`;
     } else {
       return `<a href="${link}">${shown_value}</a>`;
     }
   } else {
-    let links = "";
-    for (let l of link_urls) {
-      let link = l.link.url.replaceAll("{value}", value);
-      for (const column of columns) {
-        link = link.replaceAll(`{${column}}`, row[column]);
-      }
-      if (l.link["new-window"]) {
-        links = `${links}<a class="dropdown-item" href="${link}" target='_blank' rel="noopener noreferrer" >${l.name}</a>`;
-      } else {
-        links = `${links}<a class="dropdown-item" href="${link}" >${l.name}</a>`;
-      }
-    }
     return `
               <div class="linkout-raw-value">${shown_value}</div>
               <div class="btn-group linkout-group">
@@ -31,7 +47,7 @@ export function createLinkHtml(columns, link_urls, value, shown_value, row) {
                   ${shown_value}
                 </button>
                 <div class="dropdown-menu">
-                  ${links}
+                  ${dropdownItems(columns, link_urls, value, row, pill_value)}
                 </div>
               </div>
             `;

--- a/web/src/plot/pills.js
+++ b/web/src/plot/pills.js
@@ -3,6 +3,7 @@ import {
   isDark,
   datavzrdScale
 } from "./heatmap";
+import { createLinkHtml, dropdownItems } from "./link-to-url";
 
 function renderPill(
   value,
@@ -10,6 +11,7 @@ function renderPill(
   ellipsis,
   merge = false,
   position = "middle",
+  dropdown = false,
 ) {
   let styles = `padding: 4px 8px; background-color: ${color};`;
   if (isDark(color)) {
@@ -28,13 +30,22 @@ function renderPill(
             : "0";
     styles += `border-radius: ${radius}; margin: 0;`;
   }
+  if (dropdown) {
+    styles += "cursor: pointer;";
+  }
+  let toggle = dropdown
+    ? ' class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"'
+    : "";
+  let tooltip = dropdown
+    ? ""
+    : ' data-toggle="tooltip" data-trigger="hover click focus"';
 
   if (ellipsis === 0) {
-    return `<span style="${styles}; padding:6px 12px; height:24px; width:24px;" data-toggle="tooltip" data-trigger="hover click focus" title='${value}'></span>`;
+    return `<span style="${styles}; padding:6px 12px; height:24px; width:24px;"${toggle}${tooltip} title='${value}'></span>`;
   } else if (ellipsis === undefined || value.length <= ellipsis) {
-    return `<span style="${styles}">${value}</span>`;
+    return `<span style="${styles}"${toggle}>${value}</span>`;
   } else {
-    return `<span style="${styles}" data-toggle="tooltip" data-trigger="hover click focus" title='${value}'>${value.substring(0, ellipsis)}...</span>`;
+    return `<span style="${styles}"${toggle}${tooltip} title='${value}'>${value.substring(0, ellipsis)}...</span>`;
   }
 }
 
@@ -52,6 +63,45 @@ export function pillsToHeatmap(pills) {
   };
 }
 
+function renderPillGroup(value, pills, scale, link, columns, row) {
+  let values = value.split(pills.pills.separator).map((item) => item.trim());
+  return values
+    .map((v, i) => {
+      let pos =
+        values.length === 1
+          ? "only"
+          : i === 0
+            ? "first"
+            : i === values.length - 1
+              ? "last"
+              : "middle";
+      if (link && link.links.length > 1) {
+        let toggle = renderPill(
+          v,
+          scale(v),
+          pills.pills.ellipsis,
+          pills.pills.merge,
+          pos,
+          true,
+        );
+        let items = dropdownItems(columns, link.links, value, row, v);
+        return `<span class="btn-group pill-dropdown">${toggle}<div class="dropdown-menu">${items}</div></span>`;
+      }
+      let pill = renderPill(
+        v,
+        scale(v),
+        pills.pills.ellipsis,
+        pills.pills.merge,
+        pos,
+      );
+      if (link) {
+        return createLinkHtml(columns, link.links, value, pill, row, v);
+      }
+      return pill;
+    })
+    .join("");
+}
+
 export function renderPills(
   ah,
   columns,
@@ -59,6 +109,8 @@ export function renderPills(
   detail_mode,
   header_label_length,
   columnIndexMap,
+  link,
+  link_columns,
 ) {
   let index = columnIndexMap[pills.title];
   let row = 0;
@@ -71,61 +123,26 @@ export function renderPills(
   $(`table > tbody > tr td:nth-child(${index})`).each(function () {
     var value = table_rows[row][pills.title];
     if (value !== "") {
-      let values = value
-        .split(pills.pills.separator)
-        .map((item) => item.trim());
-      let content = values
-        .map((v, i) => {
-          let pos =
-            values.length === 1
-              ? "only"
-              : i === 0
-                ? "first"
-                : i === values.length - 1
-                  ? "last"
-                  : "middle";
-          let color = scale(v);
-          return renderPill(
-            v,
-            color,
-            pills.pills.ellipsis,
-            pills.pills.merge,
-            pos,
-          );
-        })
-        .join("");
-      this.innerHTML = `<div style="display: inline-block; margin: 8px 0;">${content}</div>`;
+      let content = renderPillGroup(
+        value,
+        pills,
+        scale,
+        link,
+        link_columns,
+        table_rows[row],
+      );
+      this.innerHTML = `<div class="pills-cell" style="display: inline-block; margin: 8px 0;">${content}</div>`;
     }
     row++;
   });
 }
 
-export function renderDetailPills(value, div, pills) {
+export function renderDetailPills(value, div, pills, link, link_columns, row) {
   let heatmap = pillsToHeatmap(pills);
   let scale = datavzrdScale(heatmap);
 
   if (value !== "") {
-    let values = value.split(pills.pills.separator).map((item) => item.trim());
-    let content = values
-      .map((v, i) => {
-        let pos =
-          values.length === 1
-            ? "only"
-            : i === 0
-              ? "first"
-              : i === values.length - 1
-                ? "last"
-                : "middle";
-        let color = scale(v);
-        return renderPill(
-          v,
-          color,
-          pills.pills.ellipsis,
-          pills.pills.merge,
-          pos,
-        );
-      })
-      .join("");
+    let content = renderPillGroup(value, pills, scale, link, link_columns, row);
     $(`${div}`)[0].innerHTML = `<div class="detail-pills-wrapper">${content}</div>`;
   }
   $('[data-toggle="tooltip"]').tooltip({

--- a/web/style/datavzrd.css
+++ b/web/style/datavzrd.css
@@ -471,3 +471,33 @@ th.col-drag-over {
   font-weight: 500;
   font-size: inherit;
 }
+
+.pills-cell a,
+.detail-pills-wrapper a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.linked-cell a {
+  color: inherit;
+}
+
+.linked-cell .dropdown-toggle {
+  color: inherit;
+  border-color: currentColor;
+}
+
+.pill-dropdown {
+  display: inline-block;
+}
+
+.centered-card {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+}
+
+.detail-pills-wrapper {
+  padding: 4px 0;
+}


### PR DESCRIPTION
Lets `link-to-url` compose with pills and heatmap columns: each pill becomes its own link via a new `{pill-value}` placeholder while `{value}` stays the whole cell, and heatmap cells become clickable, in both normal and detail view for single and multiple links. Also fixes a pre-existing bug where legend rendering mutated the shared heatmap config in place.